### PR TITLE
Add jupyter support

### DIFF
--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -102,6 +102,7 @@ RUN pip install --no-cache-dir \
         mock coverage \
         sphinx sphinx-rtd-theme \
         seaborn ipympl \
+        jupyter \
     && rm -rf /tmp/*
 
 CMD ["bash"]

--- a/Dockerfile-windows.template
+++ b/Dockerfile-windows.template
@@ -35,6 +35,7 @@ RUN pip install --no-cache-dir \
         pandas scipy scikit-learn imbalanced-learn tabulate \
         mock coverage \
         sphinx sphinx-rtd-theme \
-        seaborn ipympl
+        seaborn ipympl \
+        jupyter
 
 CMD ["bash"]

--- a/dockerfiles/6/python3.10/bullseye/Dockerfile
+++ b/dockerfiles/6/python3.10/bullseye/Dockerfile
@@ -102,6 +102,7 @@ RUN pip install --no-cache-dir \
         mock coverage \
         sphinx sphinx-rtd-theme \
         seaborn ipympl \
+        jupyter \
     && rm -rf /tmp/*
 
 CMD ["bash"]

--- a/dockerfiles/6/python3.10/windowsservercore/Dockerfile
+++ b/dockerfiles/6/python3.10/windowsservercore/Dockerfile
@@ -35,6 +35,7 @@ RUN pip install --no-cache-dir \
         pandas scipy scikit-learn imbalanced-learn tabulate \
         mock coverage \
         sphinx sphinx-rtd-theme \
-        seaborn ipympl
+        seaborn ipympl \
+        jupyter
 
 CMD ["bash"]

--- a/dockerfiles/6/python3.11/bullseye/Dockerfile
+++ b/dockerfiles/6/python3.11/bullseye/Dockerfile
@@ -102,6 +102,7 @@ RUN pip install --no-cache-dir \
         mock coverage \
         sphinx sphinx-rtd-theme \
         seaborn ipympl \
+        jupyter \
     && rm -rf /tmp/*
 
 CMD ["bash"]

--- a/dockerfiles/6/python3.11/windowsservercore/Dockerfile
+++ b/dockerfiles/6/python3.11/windowsservercore/Dockerfile
@@ -35,6 +35,7 @@ RUN pip install --no-cache-dir \
         pandas scipy scikit-learn imbalanced-learn tabulate \
         mock coverage \
         sphinx sphinx-rtd-theme \
-        seaborn ipympl
+        seaborn ipympl \
+        jupyter
 
 CMD ["bash"]

--- a/dockerfiles/6/python3.9/bullseye/Dockerfile
+++ b/dockerfiles/6/python3.9/bullseye/Dockerfile
@@ -102,6 +102,7 @@ RUN pip install --no-cache-dir \
         mock coverage \
         sphinx sphinx-rtd-theme \
         seaborn ipympl \
+        jupyter \
     && rm -rf /tmp/*
 
 CMD ["bash"]

--- a/dockerfiles/6/python3.9/windowsservercore/Dockerfile
+++ b/dockerfiles/6/python3.9/windowsservercore/Dockerfile
@@ -35,6 +35,7 @@ RUN pip install --no-cache-dir \
         pandas scipy scikit-learn imbalanced-learn tabulate \
         mock coverage \
         sphinx sphinx-rtd-theme \
-        seaborn ipympl
+        seaborn ipympl \
+        jupyter
 
 CMD ["bash"]


### PR DESCRIPTION
Jupyter et al adds 100MB to container size. We should consider using `slim` for base.