### PR TITLE
Define vscode's `python.defaultInterpreterPath` in devcontainer metadata

### DIFF
--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -58,6 +58,9 @@ ENV \
     # supress pip version warnings (presumably pip will always be close to latest in our image)
     PIP_DISABLE_PIP_VERSION_CHECK=1
 
+# specify default python interpreter in the embedded devcontainer metadata
+LABEL devcontainer.metadata="[{\"customizations\": {\"vscode\": {\"extensions\": [\"ms-python.python\"], \"settings\": {\"python.defaultInterpreterPath\": \"/usr/local/bin/python\"}}}}]"
+
 # use sudo so that user does not get sudo usage info on (the first) login
 USER user
 RUN sudo echo "Running 'sudo' for user: success"

--- a/dockerfiles/6/python3.10/bullseye/Dockerfile
+++ b/dockerfiles/6/python3.10/bullseye/Dockerfile
@@ -58,6 +58,9 @@ ENV \
     # supress pip version warnings (presumably pip will always be close to latest in our image)
     PIP_DISABLE_PIP_VERSION_CHECK=1
 
+# specify default python interpreter in the embedded devcontainer metadata
+LABEL devcontainer.metadata="[{\"customizations\": {\"vscode\": {\"extensions\": [\"ms-python.python\"], \"settings\": {\"python.defaultInterpreterPath\": \"/usr/local/bin/python\"}}}}]"
+
 # use sudo so that user does not get sudo usage info on (the first) login
 USER user
 RUN sudo echo "Running 'sudo' for user: success"

--- a/dockerfiles/6/python3.11/bullseye/Dockerfile
+++ b/dockerfiles/6/python3.11/bullseye/Dockerfile
@@ -58,6 +58,9 @@ ENV \
     # supress pip version warnings (presumably pip will always be close to latest in our image)
     PIP_DISABLE_PIP_VERSION_CHECK=1
 
+# specify default python interpreter in the embedded devcontainer metadata
+LABEL devcontainer.metadata="[{\"customizations\": {\"vscode\": {\"extensions\": [\"ms-python.python\"], \"settings\": {\"python.defaultInterpreterPath\": \"/usr/local/bin/python\"}}}}]"
+
 # use sudo so that user does not get sudo usage info on (the first) login
 USER user
 RUN sudo echo "Running 'sudo' for user: success"

--- a/dockerfiles/6/python3.12/bullseye/Dockerfile
+++ b/dockerfiles/6/python3.12/bullseye/Dockerfile
@@ -58,6 +58,9 @@ ENV \
     # supress pip version warnings (presumably pip will always be close to latest in our image)
     PIP_DISABLE_PIP_VERSION_CHECK=1
 
+# specify default python interpreter in the embedded devcontainer metadata
+LABEL devcontainer.metadata="[{\"customizations\": {\"vscode\": {\"extensions\": [\"ms-python.python\"], \"settings\": {\"python.defaultInterpreterPath\": \"/usr/local/bin/python\"}}}}]"
+
 # use sudo so that user does not get sudo usage info on (the first) login
 USER user
 RUN sudo echo "Running 'sudo' for user: success"

--- a/dockerfiles/6/python3.9/bullseye/Dockerfile
+++ b/dockerfiles/6/python3.9/bullseye/Dockerfile
@@ -58,6 +58,9 @@ ENV \
     # supress pip version warnings (presumably pip will always be close to latest in our image)
     PIP_DISABLE_PIP_VERSION_CHECK=1
 
+# specify default python interpreter in the embedded devcontainer metadata
+LABEL devcontainer.metadata="[{\"customizations\": {\"vscode\": {\"extensions\": [\"ms-python.python\"], \"settings\": {\"python.defaultInterpreterPath\": \"/usr/local/bin/python\"}}}}]"
+
 # use sudo so that user does not get sudo usage info on (the first) login
 USER user
 RUN sudo echo "Running 'sudo' for user: success"


### PR DESCRIPTION
Implement a subset of #15, as an immediate fix to [a known issue](https://github.com/dwavesystems/ocean-devcontainer/issues/2).