### PR TITLE
Build Ocean 7.1.0 images

### DIFF
--- a/.circleci/build.yml
+++ b/.circleci/build.yml
@@ -243,6 +243,7 @@ workflows:
             parameters:
               # list manually for now; long-term, we want to auto-generate this list from the main runner
               path: &linux-dockerfiles [
+                "dockerfiles/7/python3.9/bullseye",
                 "dockerfiles/7/python3.10/bullseye",
                 "dockerfiles/7/python3.11/bullseye",
                 "dockerfiles/7/python3.12/bullseye",
@@ -266,6 +267,7 @@ workflows:
             parameters:
               # list manually for now; long-term, we want to auto-generate this list from the main runner
               path: &windows-dockerfiles [
+                "dockerfiles/7/python3.9/windowsservercore",
                 "dockerfiles/7/python3.10/windowsservercore",
                 "dockerfiles/7/python3.11/windowsservercore",
                 "dockerfiles/7/python3.12/windowsservercore",

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ and optional non-open-source Ocean packages like
 
 ## Build Matrix
 
-- Ocean: [`7.0.0`](https://github.com/dwavesystems/dwave-ocean-sdk/releases/7.0.0)
+- Ocean: [`7.1.0`](https://github.com/dwavesystems/dwave-ocean-sdk/releases/7.1.0)
 - Python: `3.9`, `3.10`, **`3.11`** (default), `3.12`
 - Platform: [`bullseye`](https://wiki.debian.org/DebianBullseye), `windowsservercore`
 
@@ -37,62 +37,77 @@ Shared tags map to multi-platform/multi-architecture images.
 
 ### Simple Tags
 
-- [Ocean: `7.0.0`, Python: `3.11`, Platform: `bullseye`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/7/python3.11/bullseye/Dockerfile)
+- [Ocean: `7.1.0`, Python: `3.11`, Platform: `bullseye`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/7/python3.11/bullseye/Dockerfile)
   - `7-bullseye`
   - `7-python3.11-bullseye`
-  - `7.0-bullseye`
-  - `7.0-python3.11-bullseye`
-  - `7.0.0-bullseye`
-  - `7.0.0-python3.11-bullseye`
+  - `7.1-bullseye`
+  - `7.1-python3.11-bullseye`
+  - `7.1.0-bullseye`
+  - `7.1.0-python3.11-bullseye`
   - `bullseye`
   - `python3.11-bullseye`
 
-- [Ocean: `7.0.0`, Python: `3.11`, Platform: `windowsservercore`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/7/python3.11/windowsservercore/Dockerfile)
+- [Ocean: `7.1.0`, Python: `3.11`, Platform: `windowsservercore`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/7/python3.11/windowsservercore/Dockerfile)
   - `7-python3.11-windowsservercore`
   - `7-windowsservercore`
-  - `7.0-python3.11-windowsservercore`
-  - `7.0-windowsservercore`
-  - `7.0.0-python3.11-windowsservercore`
-  - `7.0.0-windowsservercore`
+  - `7.1-python3.11-windowsservercore`
+  - `7.1-windowsservercore`
+  - `7.1.0-python3.11-windowsservercore`
+  - `7.1.0-windowsservercore`
   - `python3.11-windowsservercore`
   - `windowsservercore`
 
-- [Ocean: `7.0.0`, Python: `3.10`, Platform: `bullseye`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/7/python3.10/bullseye/Dockerfile)
+- [Ocean: `7.1.0`, Python: `3.9`, Platform: `bullseye`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/7/python3.9/bullseye/Dockerfile)
+  - `7-python3.9-bullseye`
+  - `7.1-python3.9-bullseye`
+  - `7.1.0-python3.9-bullseye`
+  - `python3.9-bullseye`
+
+- [Ocean: `7.1.0`, Python: `3.9`, Platform: `windowsservercore`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/7/python3.9/windowsservercore/Dockerfile)
+  - `7-python3.9-windowsservercore`
+  - `7.1-python3.9-windowsservercore`
+  - `7.1.0-python3.9-windowsservercore`
+  - `python3.9-windowsservercore`
+
+- [Ocean: `7.1.0`, Python: `3.10`, Platform: `bullseye`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/7/python3.10/bullseye/Dockerfile)
   - `7-python3.10-bullseye`
-  - `7.0-python3.10-bullseye`
-  - `7.0.0-python3.10-bullseye`
+  - `7.1-python3.10-bullseye`
+  - `7.1.0-python3.10-bullseye`
   - `python3.10-bullseye`
 
-- [Ocean: `7.0.0`, Python: `3.10`, Platform: `windowsservercore`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/7/python3.10/windowsservercore/Dockerfile)
+- [Ocean: `7.1.0`, Python: `3.10`, Platform: `windowsservercore`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/7/python3.10/windowsservercore/Dockerfile)
   - `7-python3.10-windowsservercore`
-  - `7.0-python3.10-windowsservercore`
-  - `7.0.0-python3.10-windowsservercore`
+  - `7.1-python3.10-windowsservercore`
+  - `7.1.0-python3.10-windowsservercore`
   - `python3.10-windowsservercore`
 
-- [Ocean: `7.0.0`, Python: `3.12`, Platform: `bullseye`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/7/python3.12/bullseye/Dockerfile)
+- [Ocean: `7.1.0`, Python: `3.12`, Platform: `bullseye`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/7/python3.12/bullseye/Dockerfile)
   - `7-python3.12-bullseye`
-  - `7.0-python3.12-bullseye`
-  - `7.0.0-python3.12-bullseye`
+  - `7.1-python3.12-bullseye`
+  - `7.1.0-python3.12-bullseye`
   - `python3.12-bullseye`
 
-- [Ocean: `7.0.0`, Python: `3.12`, Platform: `windowsservercore`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/7/python3.12/windowsservercore/Dockerfile)
+- [Ocean: `7.1.0`, Python: `3.12`, Platform: `windowsservercore`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/7/python3.12/windowsservercore/Dockerfile)
   - `7-python3.12-windowsservercore`
-  - `7.0-python3.12-windowsservercore`
-  - `7.0.0-python3.12-windowsservercore`
+  - `7.1-python3.12-windowsservercore`
+  - `7.1.0-python3.12-windowsservercore`
   - `python3.12-windowsservercore`
 
 
 ### Shared Tags
 
-- `7-python3.10`, `7.0-python3.10`, `7.0.0-python3.10`, `python3.10`
-  - [`7.0.0-python3.10-bullseye`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/7/python3.10/bullseye/Dockerfile)
-  - [`7.0.0-python3.10-windowsservercore`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/7/python3.10/windowsservercore/Dockerfile)
-- `7`, `7-python3.11`, `7.0`, `7.0-python3.11`, `7.0.0`, `7.0.0-python3.11`, `latest`, `python3.11`
-  - [`7.0.0-python3.11-bullseye`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/7/python3.11/bullseye/Dockerfile)
-  - [`7.0.0-python3.11-windowsservercore`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/7/python3.11/windowsservercore/Dockerfile)
-- `7-python3.12`, `7.0-python3.12`, `7.0.0-python3.12`, `python3.12`
-  - [`7.0.0-python3.12-bullseye`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/7/python3.12/bullseye/Dockerfile)
-  - [`7.0.0-python3.12-windowsservercore`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/7/python3.12/windowsservercore/Dockerfile)
+- `7-python3.10`, `7.1-python3.10`, `7.1.0-python3.10`, `python3.10`
+  - [`7.1.0-python3.10-bullseye`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/7/python3.10/bullseye/Dockerfile)
+  - [`7.1.0-python3.10-windowsservercore`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/7/python3.10/windowsservercore/Dockerfile)
+- `7`, `7-python3.11`, `7.1`, `7.1-python3.11`, `7.1.0`, `7.1.0-python3.11`, `latest`, `python3.11`
+  - [`7.1.0-python3.11-bullseye`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/7/python3.11/bullseye/Dockerfile)
+  - [`7.1.0-python3.11-windowsservercore`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/7/python3.11/windowsservercore/Dockerfile)
+- `7-python3.12`, `7.1-python3.12`, `7.1.0-python3.12`, `python3.12`
+  - [`7.1.0-python3.12-bullseye`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/7/python3.12/bullseye/Dockerfile)
+  - [`7.1.0-python3.12-windowsservercore`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/7/python3.12/windowsservercore/Dockerfile)
+- `7-python3.9`, `7.1-python3.9`, `7.1.0-python3.9`, `python3.9`
+  - [`7.1.0-python3.9-bullseye`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/7/python3.9/bullseye/Dockerfile)
+  - [`7.1.0-python3.9-windowsservercore`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/7/python3.9/windowsservercore/Dockerfile)
 
 
 ## License

--- a/build.json
+++ b/build.json
@@ -1,7 +1,7 @@
 {
     "matrix": {
         "ocean": [null, "{ocean.major}", "{ocean.minor}", "{ocean.patch}"],
-        "python": [null, "3.10", "3.11", "3.12"],
+        "python": [null, "3.9", "3.10", "3.11", "3.12"],
         "platform": ["bullseye", "windowsservercore"]
     },
     "exclude": [],
@@ -26,7 +26,7 @@
     "shared": {
         "matrix": {
             "ocean": [null, "{ocean.major}", "{ocean.minor}", "{ocean.patch}"],
-            "python": [null, "3.10", "3.11", "3.12"],
+            "python": [null, "3.9", "3.10", "3.11", "3.12"],
             "platform": [null]
         },
         "contracted": [

--- a/data/auth-tip.sh
+++ b/data/auth-tip.sh
@@ -6,7 +6,7 @@ print_auth_tip() {
 
 		To authorize Ocean to access Leap (and retrieve your Solver API token) please run:
 
-		    dwave auth login --oob && dwave config create --auto-token
+		    dwave setup --oob
 
 		More details available in the documentation: https://docs.ocean.dwavesys.com/auth.
 	END

--- a/dockerfiles/7/python3.10/bullseye/Dockerfile
+++ b/dockerfiles/7/python3.10/bullseye/Dockerfile
@@ -50,7 +50,7 @@ WORKDIR $HOME
 
 ENV \
     # expose canonical image version
-    OCEAN_DEV_IMAGE_VERSION="7.0.0-python3.10-bullseye" \
+    OCEAN_DEV_IMAGE_VERSION="7.1.0-python3.10-bullseye" \
     \
     # we need PATH for user python packages during build as well
     PATH="$HOME/.local/bin:$PATH" \
@@ -79,7 +79,7 @@ RUN { echo && echo "~/auth-tip.sh"; } >> .bashrc
 # merge requirements gracefully (e.g. `requests` and `requests[socks]`)
 RUN pip install --no-cache-dir --upgrade pip setuptools wheel \
     && pip install --no-cache-dir \
-        dwave-ocean-sdk[all]==7.0.0 \
+        dwave-ocean-sdk[all]==7.1.0 \
         dwave-scikit-learn-plugin \
     # create site for user data home, as returned by homebase (xdg spec)
     && mkdir -p /home/user/.local/share \

--- a/dockerfiles/7/python3.10/bullseye/tags.json
+++ b/dockerfiles/7/python3.10/bullseye/tags.json
@@ -1,12 +1,12 @@
 {
-  "canonical_tag": "7.0.0-python3.10-bullseye",
+  "canonical_tag": "7.1.0-python3.10-bullseye",
   "alias_tags": [
     "7-python3.10-bullseye",
-    "7.0-python3.10-bullseye",
+    "7.1-python3.10-bullseye",
     "python3.10-bullseye"
   ],
   "subtags": {
-    "ocean": "7.0.0",
+    "ocean": "7.1.0",
     "python": "3.10",
     "platform": "bullseye"
   }

--- a/dockerfiles/7/python3.10/windowsservercore/Dockerfile
+++ b/dockerfiles/7/python3.10/windowsservercore/Dockerfile
@@ -8,7 +8,7 @@ FROM python:3.10-windowsservercore
 
 ENV \
     # expose canonical image version
-    OCEAN_DEV_IMAGE_VERSION="7.0.0-python3.10-windowsservercore" \
+    OCEAN_DEV_IMAGE_VERSION="7.1.0-python3.10-windowsservercore" \
     \
     # supress pip version warnings (presumably pip will always be close to latest in our image)
     PIP_DISABLE_PIP_VERSION_CHECK=1
@@ -19,7 +19,7 @@ RUN python -m pip install --no-cache-dir --upgrade pip setuptools wheel
 # install Ocean independently of other packages because pip is unable to
 # merge requirements gracefully (e.g. `requests` and `requests[socks]`)
 RUN pip install --no-cache-dir \
-        dwave-ocean-sdk[all]==7.0.0 \
+        dwave-ocean-sdk[all]==7.1.0 \
         dwave-scikit-learn-plugin
     # TODO: create site for user data home, as returned by homebase (xdg spec)
     # TODO: delete temporary files, if any

--- a/dockerfiles/7/python3.10/windowsservercore/tags.json
+++ b/dockerfiles/7/python3.10/windowsservercore/tags.json
@@ -1,12 +1,12 @@
 {
-  "canonical_tag": "7.0.0-python3.10-windowsservercore",
+  "canonical_tag": "7.1.0-python3.10-windowsservercore",
   "alias_tags": [
     "7-python3.10-windowsservercore",
-    "7.0-python3.10-windowsservercore",
+    "7.1-python3.10-windowsservercore",
     "python3.10-windowsservercore"
   ],
   "subtags": {
-    "ocean": "7.0.0",
+    "ocean": "7.1.0",
     "python": "3.10",
     "platform": "windowsservercore"
   }

--- a/dockerfiles/7/python3.11/bullseye/Dockerfile
+++ b/dockerfiles/7/python3.11/bullseye/Dockerfile
@@ -50,7 +50,7 @@ WORKDIR $HOME
 
 ENV \
     # expose canonical image version
-    OCEAN_DEV_IMAGE_VERSION="7.0.0-python3.11-bullseye" \
+    OCEAN_DEV_IMAGE_VERSION="7.1.0-python3.11-bullseye" \
     \
     # we need PATH for user python packages during build as well
     PATH="$HOME/.local/bin:$PATH" \
@@ -79,7 +79,7 @@ RUN { echo && echo "~/auth-tip.sh"; } >> .bashrc
 # merge requirements gracefully (e.g. `requests` and `requests[socks]`)
 RUN pip install --no-cache-dir --upgrade pip setuptools wheel \
     && pip install --no-cache-dir \
-        dwave-ocean-sdk[all]==7.0.0 \
+        dwave-ocean-sdk[all]==7.1.0 \
         dwave-scikit-learn-plugin \
     # create site for user data home, as returned by homebase (xdg spec)
     && mkdir -p /home/user/.local/share \

--- a/dockerfiles/7/python3.11/bullseye/tags.json
+++ b/dockerfiles/7/python3.11/bullseye/tags.json
@@ -1,16 +1,16 @@
 {
-  "canonical_tag": "7.0.0-python3.11-bullseye",
+  "canonical_tag": "7.1.0-python3.11-bullseye",
   "alias_tags": [
     "7-bullseye",
     "7-python3.11-bullseye",
-    "7.0-bullseye",
-    "7.0-python3.11-bullseye",
-    "7.0.0-bullseye",
+    "7.1-bullseye",
+    "7.1-python3.11-bullseye",
+    "7.1.0-bullseye",
     "bullseye",
     "python3.11-bullseye"
   ],
   "subtags": {
-    "ocean": "7.0.0",
+    "ocean": "7.1.0",
     "python": "3.11",
     "platform": "bullseye"
   }

--- a/dockerfiles/7/python3.11/windowsservercore/tags.json
+++ b/dockerfiles/7/python3.11/windowsservercore/tags.json
@@ -1,16 +1,16 @@
 {
-  "canonical_tag": "7.0.0-python3.11-windowsservercore",
+  "canonical_tag": "7.1.0-python3.11-windowsservercore",
   "alias_tags": [
     "7-python3.11-windowsservercore",
     "7-windowsservercore",
-    "7.0-python3.11-windowsservercore",
-    "7.0-windowsservercore",
-    "7.0.0-windowsservercore",
+    "7.1-python3.11-windowsservercore",
+    "7.1-windowsservercore",
+    "7.1.0-windowsservercore",
     "python3.11-windowsservercore",
     "windowsservercore"
   ],
   "subtags": {
-    "ocean": "7.0.0",
+    "ocean": "7.1.0",
     "python": "3.11",
     "platform": "windowsservercore"
   }

--- a/dockerfiles/7/python3.12/bullseye/tags.json
+++ b/dockerfiles/7/python3.12/bullseye/tags.json
@@ -1,12 +1,12 @@
 {
-  "canonical_tag": "7.0.0-python3.12-bullseye",
+  "canonical_tag": "7.1.0-python3.12-bullseye",
   "alias_tags": [
     "7-python3.12-bullseye",
-    "7.0-python3.12-bullseye",
+    "7.1-python3.12-bullseye",
     "python3.12-bullseye"
   ],
   "subtags": {
-    "ocean": "7.0.0",
+    "ocean": "7.1.0",
     "python": "3.12",
     "platform": "bullseye"
   }

--- a/dockerfiles/7/python3.12/windowsservercore/Dockerfile
+++ b/dockerfiles/7/python3.12/windowsservercore/Dockerfile
@@ -8,7 +8,7 @@ FROM python:3.12-windowsservercore
 
 ENV \
     # expose canonical image version
-    OCEAN_DEV_IMAGE_VERSION="7.0.0-python3.12-windowsservercore" \
+    OCEAN_DEV_IMAGE_VERSION="7.1.0-python3.12-windowsservercore" \
     \
     # supress pip version warnings (presumably pip will always be close to latest in our image)
     PIP_DISABLE_PIP_VERSION_CHECK=1
@@ -19,7 +19,7 @@ RUN python -m pip install --no-cache-dir --upgrade pip setuptools wheel
 # install Ocean independently of other packages because pip is unable to
 # merge requirements gracefully (e.g. `requests` and `requests[socks]`)
 RUN pip install --no-cache-dir \
-        dwave-ocean-sdk[all]==7.0.0 \
+        dwave-ocean-sdk[all]==7.1.0 \
         dwave-scikit-learn-plugin
     # TODO: create site for user data home, as returned by homebase (xdg spec)
     # TODO: delete temporary files, if any

--- a/dockerfiles/7/python3.12/windowsservercore/tags.json
+++ b/dockerfiles/7/python3.12/windowsservercore/tags.json
@@ -1,12 +1,12 @@
 {
-  "canonical_tag": "7.0.0-python3.12-windowsservercore",
+  "canonical_tag": "7.1.0-python3.12-windowsservercore",
   "alias_tags": [
     "7-python3.12-windowsservercore",
-    "7.0-python3.12-windowsservercore",
+    "7.1-python3.12-windowsservercore",
     "python3.12-windowsservercore"
   ],
   "subtags": {
-    "ocean": "7.0.0",
+    "ocean": "7.1.0",
     "python": "3.12",
     "platform": "windowsservercore"
   }

--- a/dockerfiles/7/python3.9/bullseye/Dockerfile
+++ b/dockerfiles/7/python3.9/bullseye/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM python:3.12-bullseye
+FROM python:3.9-bullseye
 
 # setup locale
 RUN apt-get update \
@@ -50,7 +50,7 @@ WORKDIR $HOME
 
 ENV \
     # expose canonical image version
-    OCEAN_DEV_IMAGE_VERSION="7.1.0-python3.12-bullseye" \
+    OCEAN_DEV_IMAGE_VERSION="7.1.0-python3.9-bullseye" \
     \
     # we need PATH for user python packages during build as well
     PATH="$HOME/.local/bin:$PATH" \

--- a/dockerfiles/7/python3.9/bullseye/tags.json
+++ b/dockerfiles/7/python3.9/bullseye/tags.json
@@ -1,0 +1,13 @@
+{
+  "canonical_tag": "7.1.0-python3.9-bullseye",
+  "alias_tags": [
+    "7-python3.9-bullseye",
+    "7.1-python3.9-bullseye",
+    "python3.9-bullseye"
+  ],
+  "subtags": {
+    "ocean": "7.1.0",
+    "python": "3.9",
+    "platform": "bullseye"
+  }
+}

--- a/dockerfiles/7/python3.9/windowsservercore/Dockerfile
+++ b/dockerfiles/7/python3.9/windowsservercore/Dockerfile
@@ -4,11 +4,11 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM python:3.11-windowsservercore
+FROM python:3.9-windowsservercore
 
 ENV \
     # expose canonical image version
-    OCEAN_DEV_IMAGE_VERSION="7.1.0-python3.11-windowsservercore" \
+    OCEAN_DEV_IMAGE_VERSION="7.1.0-python3.9-windowsservercore" \
     \
     # supress pip version warnings (presumably pip will always be close to latest in our image)
     PIP_DISABLE_PIP_VERSION_CHECK=1

--- a/dockerfiles/7/python3.9/windowsservercore/tags.json
+++ b/dockerfiles/7/python3.9/windowsservercore/tags.json
@@ -1,0 +1,13 @@
+{
+  "canonical_tag": "7.1.0-python3.9-windowsservercore",
+  "alias_tags": [
+    "7-python3.9-windowsservercore",
+    "7.1-python3.9-windowsservercore",
+    "python3.9-windowsservercore"
+  ],
+  "subtags": {
+    "ocean": "7.1.0",
+    "python": "3.9",
+    "platform": "windowsservercore"
+  }
+}

--- a/dockerfiles/7/shared-tags.json
+++ b/dockerfiles/7/shared-tags.json
@@ -1,66 +1,82 @@
 {
   "latest": [
-    "7.0.0-python3.11-bullseye",
-    "7.0.0-python3.11-windowsservercore"
+    "7.1.0-python3.11-bullseye",
+    "7.1.0-python3.11-windowsservercore"
+  ],
+  "python3.9": [
+    "7.1.0-python3.9-bullseye",
+    "7.1.0-python3.9-windowsservercore"
   ],
   "python3.10": [
-    "7.0.0-python3.10-bullseye",
-    "7.0.0-python3.10-windowsservercore"
+    "7.1.0-python3.10-bullseye",
+    "7.1.0-python3.10-windowsservercore"
   ],
   "python3.11": [
-    "7.0.0-python3.11-bullseye",
-    "7.0.0-python3.11-windowsservercore"
+    "7.1.0-python3.11-bullseye",
+    "7.1.0-python3.11-windowsservercore"
   ],
   "python3.12": [
-    "7.0.0-python3.12-bullseye",
-    "7.0.0-python3.12-windowsservercore"
+    "7.1.0-python3.12-bullseye",
+    "7.1.0-python3.12-windowsservercore"
   ],
   "7": [
-    "7.0.0-python3.11-bullseye",
-    "7.0.0-python3.11-windowsservercore"
+    "7.1.0-python3.11-bullseye",
+    "7.1.0-python3.11-windowsservercore"
+  ],
+  "7-python3.9": [
+    "7.1.0-python3.9-bullseye",
+    "7.1.0-python3.9-windowsservercore"
   ],
   "7-python3.10": [
-    "7.0.0-python3.10-bullseye",
-    "7.0.0-python3.10-windowsservercore"
+    "7.1.0-python3.10-bullseye",
+    "7.1.0-python3.10-windowsservercore"
   ],
   "7-python3.11": [
-    "7.0.0-python3.11-bullseye",
-    "7.0.0-python3.11-windowsservercore"
+    "7.1.0-python3.11-bullseye",
+    "7.1.0-python3.11-windowsservercore"
   ],
   "7-python3.12": [
-    "7.0.0-python3.12-bullseye",
-    "7.0.0-python3.12-windowsservercore"
+    "7.1.0-python3.12-bullseye",
+    "7.1.0-python3.12-windowsservercore"
   ],
-  "7.0": [
-    "7.0.0-python3.11-bullseye",
-    "7.0.0-python3.11-windowsservercore"
+  "7.1": [
+    "7.1.0-python3.11-bullseye",
+    "7.1.0-python3.11-windowsservercore"
   ],
-  "7.0-python3.10": [
-    "7.0.0-python3.10-bullseye",
-    "7.0.0-python3.10-windowsservercore"
+  "7.1-python3.9": [
+    "7.1.0-python3.9-bullseye",
+    "7.1.0-python3.9-windowsservercore"
   ],
-  "7.0-python3.11": [
-    "7.0.0-python3.11-bullseye",
-    "7.0.0-python3.11-windowsservercore"
+  "7.1-python3.10": [
+    "7.1.0-python3.10-bullseye",
+    "7.1.0-python3.10-windowsservercore"
   ],
-  "7.0-python3.12": [
-    "7.0.0-python3.12-bullseye",
-    "7.0.0-python3.12-windowsservercore"
+  "7.1-python3.11": [
+    "7.1.0-python3.11-bullseye",
+    "7.1.0-python3.11-windowsservercore"
   ],
-  "7.0.0": [
-    "7.0.0-python3.11-bullseye",
-    "7.0.0-python3.11-windowsservercore"
+  "7.1-python3.12": [
+    "7.1.0-python3.12-bullseye",
+    "7.1.0-python3.12-windowsservercore"
   ],
-  "7.0.0-python3.10": [
-    "7.0.0-python3.10-bullseye",
-    "7.0.0-python3.10-windowsservercore"
+  "7.1.0": [
+    "7.1.0-python3.11-bullseye",
+    "7.1.0-python3.11-windowsservercore"
   ],
-  "7.0.0-python3.11": [
-    "7.0.0-python3.11-bullseye",
-    "7.0.0-python3.11-windowsservercore"
+  "7.1.0-python3.9": [
+    "7.1.0-python3.9-bullseye",
+    "7.1.0-python3.9-windowsservercore"
   ],
-  "7.0.0-python3.12": [
-    "7.0.0-python3.12-bullseye",
-    "7.0.0-python3.12-windowsservercore"
+  "7.1.0-python3.10": [
+    "7.1.0-python3.10-bullseye",
+    "7.1.0-python3.10-windowsservercore"
+  ],
+  "7.1.0-python3.11": [
+    "7.1.0-python3.11-bullseye",
+    "7.1.0-python3.11-windowsservercore"
+  ],
+  "7.1.0-python3.12": [
+    "7.1.0-python3.12-bullseye",
+    "7.1.0-python3.12-windowsservercore"
   ]
 }


### PR DESCRIPTION
- **Add Python 3.9 back (revert 8f043cafda)**
- **Update auth-tip to print a simplified setup command: `dwave setup --oob`**
- **Generate Ocean 7.1.0 dockerfiles, tags and readme**
