### PR TITLE
Add debian trixie images

### DIFF
--- a/.circleci/build.yml
+++ b/.circleci/build.yml
@@ -244,10 +244,15 @@ workflows:
               # list manually for now; long-term, we want to auto-generate this list from the main runner
               path: &linux-dockerfiles [
                 "dockerfiles/9/python3.9/bookworm",
+                "dockerfiles/9/python3.9/trixie",
                 "dockerfiles/9/python3.10/bookworm",
+                "dockerfiles/9/python3.10/trixie",
                 "dockerfiles/9/python3.11/bookworm",
+                "dockerfiles/9/python3.11/trixie",
                 "dockerfiles/9/python3.12/bookworm",
+                "dockerfiles/9/python3.12/trixie",
                 "dockerfiles/9/python3.13/bookworm",
+                "dockerfiles/9/python3.13/trixie",
               ]
           filters: &off-master
             branches:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ and optional non-open-source Ocean packages like
 
 - Ocean: [`9.0.0`](https://github.com/dwavesystems/dwave-ocean-sdk/releases/9.0.0)
 - Python: `3.9`, `3.10`, `3.11`, **`3.12`** (default), `3.13`
-- Platform: [`bookworm`](https://wiki.debian.org/DebianBookworm), `windowsservercore`
+- Platform: [`bookworm`](https://wiki.debian.org/DebianBookworm) (default), [`trixie`](https://wiki.debian.org/DebianTrixie), `windowsservercore`
 
 
 ## Architectures
@@ -36,6 +36,16 @@ Shared tags map to multi-platform/multi-architecture images.
 
 ### Simple Tags
 
+- [Ocean: `9.0.0`, Python: `3.12`, Platform: `trixie`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/9/python3.12/trixie/Dockerfile)
+  - `9-python3.12-trixie`
+  - `9-trixie`
+  - `9.0-python3.12-trixie`
+  - `9.0-trixie`
+  - `9.0.0-python3.12-trixie`
+  - `9.0.0-trixie`
+  - `python3.12-trixie`
+  - `trixie`
+
 - [Ocean: `9.0.0`, Python: `3.12`, Platform: `bookworm`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/9/python3.12/bookworm/Dockerfile)
   - `9-bookworm`
   - `9-python3.12-bookworm`
@@ -56,6 +66,12 @@ Shared tags map to multi-platform/multi-architecture images.
   - `python3.12-windowsservercore`
   - `windowsservercore`
 
+- [Ocean: `9.0.0`, Python: `3.9`, Platform: `trixie`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/9/python3.9/trixie/Dockerfile)
+  - `9-python3.9-trixie`
+  - `9.0-python3.9-trixie`
+  - `9.0.0-python3.9-trixie`
+  - `python3.9-trixie`
+
 - [Ocean: `9.0.0`, Python: `3.9`, Platform: `bookworm`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/9/python3.9/bookworm/Dockerfile)
   - `9-python3.9-bookworm`
   - `9.0-python3.9-bookworm`
@@ -67,6 +83,12 @@ Shared tags map to multi-platform/multi-architecture images.
   - `9.0-python3.9-windowsservercore`
   - `9.0.0-python3.9-windowsservercore`
   - `python3.9-windowsservercore`
+
+- [Ocean: `9.0.0`, Python: `3.10`, Platform: `trixie`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/9/python3.10/trixie/Dockerfile)
+  - `9-python3.10-trixie`
+  - `9.0-python3.10-trixie`
+  - `9.0.0-python3.10-trixie`
+  - `python3.10-trixie`
 
 - [Ocean: `9.0.0`, Python: `3.10`, Platform: `bookworm`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/9/python3.10/bookworm/Dockerfile)
   - `9-python3.10-bookworm`
@@ -80,6 +102,12 @@ Shared tags map to multi-platform/multi-architecture images.
   - `9.0.0-python3.10-windowsservercore`
   - `python3.10-windowsservercore`
 
+- [Ocean: `9.0.0`, Python: `3.11`, Platform: `trixie`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/9/python3.11/trixie/Dockerfile)
+  - `9-python3.11-trixie`
+  - `9.0-python3.11-trixie`
+  - `9.0.0-python3.11-trixie`
+  - `python3.11-trixie`
+
 - [Ocean: `9.0.0`, Python: `3.11`, Platform: `bookworm`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/9/python3.11/bookworm/Dockerfile)
   - `9-python3.11-bookworm`
   - `9.0-python3.11-bookworm`
@@ -91,6 +119,12 @@ Shared tags map to multi-platform/multi-architecture images.
   - `9.0-python3.11-windowsservercore`
   - `9.0.0-python3.11-windowsservercore`
   - `python3.11-windowsservercore`
+
+- [Ocean: `9.0.0`, Python: `3.13`, Platform: `trixie`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/9/python3.13/trixie/Dockerfile)
+  - `9-python3.13-trixie`
+  - `9.0-python3.13-trixie`
+  - `9.0.0-python3.13-trixie`
+  - `python3.13-trixie`
 
 - [Ocean: `9.0.0`, Python: `3.13`, Platform: `bookworm`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/9/python3.13/bookworm/Dockerfile)
   - `9-python3.13-bookworm`

--- a/README.md.template
+++ b/README.md.template
@@ -14,7 +14,7 @@ and optional non-open-source Ocean packages like
 
 - Ocean: [`{{ ocean_version }}`](https://github.com/dwavesystems/dwave-ocean-sdk/releases/{{ ocean_version }})
 - Python: `3.9`, `3.10`, `3.11`, **`3.12`** (default), `3.13`
-- Platform: [`bookworm`](https://wiki.debian.org/DebianBookworm), `windowsservercore`
+- Platform: [`bookworm`](https://wiki.debian.org/DebianBookworm) (default), [`trixie`](https://wiki.debian.org/DebianTrixie), `windowsservercore`
 
 
 ## Architectures

--- a/build.json
+++ b/build.json
@@ -2,7 +2,7 @@
     "matrix": {
         "ocean": [null, "{ocean.major}", "{ocean.minor}", "{ocean.patch}"],
         "python": [null, "3.9", "3.10", "3.11", "3.12", "3.13"],
-        "platform": ["bookworm", "windowsservercore"]
+        "platform": ["trixie", "bookworm", "windowsservercore"]
     },
     "exclude": [],
     "aliases": {
@@ -17,7 +17,8 @@
     },
     "template": {
         "Dockerfile-linux.template": [
-            {"platform": "bookworm"}
+            {"platform": "bookworm"},
+            {"platform": "trixie"}
         ],
         "Dockerfile-windows.template": [
             {"platform": "windowsservercore"}

--- a/dockerfiles/9/python3.10/trixie/Dockerfile
+++ b/dockerfiles/9/python3.10/trixie/Dockerfile
@@ -1,0 +1,107 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "python generate.py dockerfiles"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM python:3.10-trixie
+
+# setup locale
+RUN apt-get update \
+    && apt-get install -yq --no-install-recommends \
+        locales \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* \
+    && sed -i 's/^# *\(en_CA.UTF-8\)/\1/' /etc/locale.gen \
+    && locale-gen
+
+ENV LANG=en_CA.UTF-8
+
+# install basic packages
+RUN apt-get update \
+    && apt-get install -yq --no-install-recommends \
+        apt-utils \
+        bash-completion \
+        build-essential \
+        man-db \
+        zip \
+        unzip \
+        procps \
+        time \
+        lsof \
+        sudo \
+        htop \
+        less \
+        vim \
+        curl \
+        git \
+        jq \
+        # debugging: strace; ss, ip; netstat, arp, route
+        strace \
+        iproute2 \
+        net-tools \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/*
+
+# add a regular user
+RUN useradd -l -u 1000 -G sudo -md /home/user -s /bin/bash -p user user \
+    # passwordless sudo for users in the 'sudo' group
+    && sed -i.bkp -e 's/%sudo\s\+ALL=(ALL\(:ALL\)\?)\s\+ALL/%sudo ALL=NOPASSWD:ALL/g' /etc/sudoers
+ENV HOME=/home/user
+WORKDIR $HOME
+
+ENV \
+    # expose canonical image version
+    OCEAN_DEV_IMAGE_VERSION="9.0.0-python3.10-trixie" \
+    \
+    # we need PATH for user python packages during build as well
+    PATH="$HOME/.local/bin:$PATH" \
+    \
+    # supress pip version warnings (presumably pip will always be close to latest in our image)
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+# specify default python interpreter in the embedded devcontainer metadata
+LABEL devcontainer.metadata="[{\"customizations\": {\"vscode\": {\"extensions\": [\"ms-python.python\"], \"settings\": {\"python.defaultInterpreterPath\": \"/usr/local/bin/python\"}}}}]"
+
+# use sudo so that user does not get sudo usage info on (the first) login
+USER user
+RUN sudo echo "Running 'sudo' for user: success"
+
+# custom Bash prompt
+RUN { echo && echo "PS1='\[\e]0;ocean-dev\w\a\]\[\033[01;32m\]ocean-dev\[\033[00m\] \[\033[01;34m\]\w\[\033[00m\] \\\$ '" ; } >> .bashrc
+
+# few aliases
+RUN { echo && echo "alias ll='ls -l'" && echo "alias la='ls -la'"; } >> .bashrc
+
+# add help tip on start
+COPY data/auth-tip.sh /home/user/
+RUN { echo && echo "~/auth-tip.sh"; } >> .bashrc
+
+# install Ocean independently of other packages because pip is unable to
+# merge requirements gracefully (e.g. `requests` and `requests[socks]`)
+RUN pip install --no-cache-dir --upgrade pip setuptools wheel \
+    && pip install --no-cache-dir \
+        dwave-ocean-sdk==9.0.0 \
+        dwave-scikit-learn-plugin \
+    # create site for user data home, as returned by homebase (xdg spec)
+    && mkdir -p /home/user/.local/share \
+    && chown user:user -R /home/user/.local \
+    && rm -rf /tmp/*
+
+# install Ocean contrib packages (under EULA)
+RUN dwave install --all --yes \
+    && rm -rf /tmp/*
+
+# make sure ~/.cache is user-writeable, as the cloud-client uses it for disk cache
+RUN mkdir -p /home/user/.cache \
+    && chown user:user -R /home/user/.cache
+
+# install useful auxiliary Ocean packages (for tests, docs, examples)
+RUN pip install --no-cache-dir \
+        matplotlib jsonschema ipython tqdm \
+        pandas scipy scikit-learn imbalanced-learn tabulate \
+        mock coverage \
+        sphinx sphinx-rtd-theme \
+        seaborn ipympl \
+        jupyter \
+    && rm -rf /tmp/*
+
+CMD ["bash"]

--- a/dockerfiles/9/python3.10/trixie/tags.json
+++ b/dockerfiles/9/python3.10/trixie/tags.json
@@ -1,0 +1,13 @@
+{
+  "canonical_tag": "9.0.0-python3.10-trixie",
+  "alias_tags": [
+    "9-python3.10-trixie",
+    "9.0-python3.10-trixie",
+    "python3.10-trixie"
+  ],
+  "subtags": {
+    "ocean": "9.0.0",
+    "python": "3.10",
+    "platform": "trixie"
+  }
+}

--- a/dockerfiles/9/python3.11/trixie/Dockerfile
+++ b/dockerfiles/9/python3.11/trixie/Dockerfile
@@ -1,0 +1,107 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "python generate.py dockerfiles"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM python:3.11-trixie
+
+# setup locale
+RUN apt-get update \
+    && apt-get install -yq --no-install-recommends \
+        locales \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* \
+    && sed -i 's/^# *\(en_CA.UTF-8\)/\1/' /etc/locale.gen \
+    && locale-gen
+
+ENV LANG=en_CA.UTF-8
+
+# install basic packages
+RUN apt-get update \
+    && apt-get install -yq --no-install-recommends \
+        apt-utils \
+        bash-completion \
+        build-essential \
+        man-db \
+        zip \
+        unzip \
+        procps \
+        time \
+        lsof \
+        sudo \
+        htop \
+        less \
+        vim \
+        curl \
+        git \
+        jq \
+        # debugging: strace; ss, ip; netstat, arp, route
+        strace \
+        iproute2 \
+        net-tools \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/*
+
+# add a regular user
+RUN useradd -l -u 1000 -G sudo -md /home/user -s /bin/bash -p user user \
+    # passwordless sudo for users in the 'sudo' group
+    && sed -i.bkp -e 's/%sudo\s\+ALL=(ALL\(:ALL\)\?)\s\+ALL/%sudo ALL=NOPASSWD:ALL/g' /etc/sudoers
+ENV HOME=/home/user
+WORKDIR $HOME
+
+ENV \
+    # expose canonical image version
+    OCEAN_DEV_IMAGE_VERSION="9.0.0-python3.11-trixie" \
+    \
+    # we need PATH for user python packages during build as well
+    PATH="$HOME/.local/bin:$PATH" \
+    \
+    # supress pip version warnings (presumably pip will always be close to latest in our image)
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+# specify default python interpreter in the embedded devcontainer metadata
+LABEL devcontainer.metadata="[{\"customizations\": {\"vscode\": {\"extensions\": [\"ms-python.python\"], \"settings\": {\"python.defaultInterpreterPath\": \"/usr/local/bin/python\"}}}}]"
+
+# use sudo so that user does not get sudo usage info on (the first) login
+USER user
+RUN sudo echo "Running 'sudo' for user: success"
+
+# custom Bash prompt
+RUN { echo && echo "PS1='\[\e]0;ocean-dev\w\a\]\[\033[01;32m\]ocean-dev\[\033[00m\] \[\033[01;34m\]\w\[\033[00m\] \\\$ '" ; } >> .bashrc
+
+# few aliases
+RUN { echo && echo "alias ll='ls -l'" && echo "alias la='ls -la'"; } >> .bashrc
+
+# add help tip on start
+COPY data/auth-tip.sh /home/user/
+RUN { echo && echo "~/auth-tip.sh"; } >> .bashrc
+
+# install Ocean independently of other packages because pip is unable to
+# merge requirements gracefully (e.g. `requests` and `requests[socks]`)
+RUN pip install --no-cache-dir --upgrade pip setuptools wheel \
+    && pip install --no-cache-dir \
+        dwave-ocean-sdk==9.0.0 \
+        dwave-scikit-learn-plugin \
+    # create site for user data home, as returned by homebase (xdg spec)
+    && mkdir -p /home/user/.local/share \
+    && chown user:user -R /home/user/.local \
+    && rm -rf /tmp/*
+
+# install Ocean contrib packages (under EULA)
+RUN dwave install --all --yes \
+    && rm -rf /tmp/*
+
+# make sure ~/.cache is user-writeable, as the cloud-client uses it for disk cache
+RUN mkdir -p /home/user/.cache \
+    && chown user:user -R /home/user/.cache
+
+# install useful auxiliary Ocean packages (for tests, docs, examples)
+RUN pip install --no-cache-dir \
+        matplotlib jsonschema ipython tqdm \
+        pandas scipy scikit-learn imbalanced-learn tabulate \
+        mock coverage \
+        sphinx sphinx-rtd-theme \
+        seaborn ipympl \
+        jupyter \
+    && rm -rf /tmp/*
+
+CMD ["bash"]

--- a/dockerfiles/9/python3.11/trixie/tags.json
+++ b/dockerfiles/9/python3.11/trixie/tags.json
@@ -1,0 +1,13 @@
+{
+  "canonical_tag": "9.0.0-python3.11-trixie",
+  "alias_tags": [
+    "9-python3.11-trixie",
+    "9.0-python3.11-trixie",
+    "python3.11-trixie"
+  ],
+  "subtags": {
+    "ocean": "9.0.0",
+    "python": "3.11",
+    "platform": "trixie"
+  }
+}

--- a/dockerfiles/9/python3.12/trixie/Dockerfile
+++ b/dockerfiles/9/python3.12/trixie/Dockerfile
@@ -1,0 +1,107 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "python generate.py dockerfiles"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM python:3.12-trixie
+
+# setup locale
+RUN apt-get update \
+    && apt-get install -yq --no-install-recommends \
+        locales \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* \
+    && sed -i 's/^# *\(en_CA.UTF-8\)/\1/' /etc/locale.gen \
+    && locale-gen
+
+ENV LANG=en_CA.UTF-8
+
+# install basic packages
+RUN apt-get update \
+    && apt-get install -yq --no-install-recommends \
+        apt-utils \
+        bash-completion \
+        build-essential \
+        man-db \
+        zip \
+        unzip \
+        procps \
+        time \
+        lsof \
+        sudo \
+        htop \
+        less \
+        vim \
+        curl \
+        git \
+        jq \
+        # debugging: strace; ss, ip; netstat, arp, route
+        strace \
+        iproute2 \
+        net-tools \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/*
+
+# add a regular user
+RUN useradd -l -u 1000 -G sudo -md /home/user -s /bin/bash -p user user \
+    # passwordless sudo for users in the 'sudo' group
+    && sed -i.bkp -e 's/%sudo\s\+ALL=(ALL\(:ALL\)\?)\s\+ALL/%sudo ALL=NOPASSWD:ALL/g' /etc/sudoers
+ENV HOME=/home/user
+WORKDIR $HOME
+
+ENV \
+    # expose canonical image version
+    OCEAN_DEV_IMAGE_VERSION="9.0.0-python3.12-trixie" \
+    \
+    # we need PATH for user python packages during build as well
+    PATH="$HOME/.local/bin:$PATH" \
+    \
+    # supress pip version warnings (presumably pip will always be close to latest in our image)
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+# specify default python interpreter in the embedded devcontainer metadata
+LABEL devcontainer.metadata="[{\"customizations\": {\"vscode\": {\"extensions\": [\"ms-python.python\"], \"settings\": {\"python.defaultInterpreterPath\": \"/usr/local/bin/python\"}}}}]"
+
+# use sudo so that user does not get sudo usage info on (the first) login
+USER user
+RUN sudo echo "Running 'sudo' for user: success"
+
+# custom Bash prompt
+RUN { echo && echo "PS1='\[\e]0;ocean-dev\w\a\]\[\033[01;32m\]ocean-dev\[\033[00m\] \[\033[01;34m\]\w\[\033[00m\] \\\$ '" ; } >> .bashrc
+
+# few aliases
+RUN { echo && echo "alias ll='ls -l'" && echo "alias la='ls -la'"; } >> .bashrc
+
+# add help tip on start
+COPY data/auth-tip.sh /home/user/
+RUN { echo && echo "~/auth-tip.sh"; } >> .bashrc
+
+# install Ocean independently of other packages because pip is unable to
+# merge requirements gracefully (e.g. `requests` and `requests[socks]`)
+RUN pip install --no-cache-dir --upgrade pip setuptools wheel \
+    && pip install --no-cache-dir \
+        dwave-ocean-sdk==9.0.0 \
+        dwave-scikit-learn-plugin \
+    # create site for user data home, as returned by homebase (xdg spec)
+    && mkdir -p /home/user/.local/share \
+    && chown user:user -R /home/user/.local \
+    && rm -rf /tmp/*
+
+# install Ocean contrib packages (under EULA)
+RUN dwave install --all --yes \
+    && rm -rf /tmp/*
+
+# make sure ~/.cache is user-writeable, as the cloud-client uses it for disk cache
+RUN mkdir -p /home/user/.cache \
+    && chown user:user -R /home/user/.cache
+
+# install useful auxiliary Ocean packages (for tests, docs, examples)
+RUN pip install --no-cache-dir \
+        matplotlib jsonschema ipython tqdm \
+        pandas scipy scikit-learn imbalanced-learn tabulate \
+        mock coverage \
+        sphinx sphinx-rtd-theme \
+        seaborn ipympl \
+        jupyter \
+    && rm -rf /tmp/*
+
+CMD ["bash"]

--- a/dockerfiles/9/python3.12/trixie/tags.json
+++ b/dockerfiles/9/python3.12/trixie/tags.json
@@ -1,0 +1,17 @@
+{
+  "canonical_tag": "9.0.0-python3.12-trixie",
+  "alias_tags": [
+    "9-python3.12-trixie",
+    "9-trixie",
+    "9.0-python3.12-trixie",
+    "9.0-trixie",
+    "9.0.0-trixie",
+    "python3.12-trixie",
+    "trixie"
+  ],
+  "subtags": {
+    "ocean": "9.0.0",
+    "python": "3.12",
+    "platform": "trixie"
+  }
+}

--- a/dockerfiles/9/python3.13/trixie/Dockerfile
+++ b/dockerfiles/9/python3.13/trixie/Dockerfile
@@ -1,0 +1,107 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "python generate.py dockerfiles"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM python:3.13-trixie
+
+# setup locale
+RUN apt-get update \
+    && apt-get install -yq --no-install-recommends \
+        locales \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* \
+    && sed -i 's/^# *\(en_CA.UTF-8\)/\1/' /etc/locale.gen \
+    && locale-gen
+
+ENV LANG=en_CA.UTF-8
+
+# install basic packages
+RUN apt-get update \
+    && apt-get install -yq --no-install-recommends \
+        apt-utils \
+        bash-completion \
+        build-essential \
+        man-db \
+        zip \
+        unzip \
+        procps \
+        time \
+        lsof \
+        sudo \
+        htop \
+        less \
+        vim \
+        curl \
+        git \
+        jq \
+        # debugging: strace; ss, ip; netstat, arp, route
+        strace \
+        iproute2 \
+        net-tools \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/*
+
+# add a regular user
+RUN useradd -l -u 1000 -G sudo -md /home/user -s /bin/bash -p user user \
+    # passwordless sudo for users in the 'sudo' group
+    && sed -i.bkp -e 's/%sudo\s\+ALL=(ALL\(:ALL\)\?)\s\+ALL/%sudo ALL=NOPASSWD:ALL/g' /etc/sudoers
+ENV HOME=/home/user
+WORKDIR $HOME
+
+ENV \
+    # expose canonical image version
+    OCEAN_DEV_IMAGE_VERSION="9.0.0-python3.13-trixie" \
+    \
+    # we need PATH for user python packages during build as well
+    PATH="$HOME/.local/bin:$PATH" \
+    \
+    # supress pip version warnings (presumably pip will always be close to latest in our image)
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+# specify default python interpreter in the embedded devcontainer metadata
+LABEL devcontainer.metadata="[{\"customizations\": {\"vscode\": {\"extensions\": [\"ms-python.python\"], \"settings\": {\"python.defaultInterpreterPath\": \"/usr/local/bin/python\"}}}}]"
+
+# use sudo so that user does not get sudo usage info on (the first) login
+USER user
+RUN sudo echo "Running 'sudo' for user: success"
+
+# custom Bash prompt
+RUN { echo && echo "PS1='\[\e]0;ocean-dev\w\a\]\[\033[01;32m\]ocean-dev\[\033[00m\] \[\033[01;34m\]\w\[\033[00m\] \\\$ '" ; } >> .bashrc
+
+# few aliases
+RUN { echo && echo "alias ll='ls -l'" && echo "alias la='ls -la'"; } >> .bashrc
+
+# add help tip on start
+COPY data/auth-tip.sh /home/user/
+RUN { echo && echo "~/auth-tip.sh"; } >> .bashrc
+
+# install Ocean independently of other packages because pip is unable to
+# merge requirements gracefully (e.g. `requests` and `requests[socks]`)
+RUN pip install --no-cache-dir --upgrade pip setuptools wheel \
+    && pip install --no-cache-dir \
+        dwave-ocean-sdk==9.0.0 \
+        dwave-scikit-learn-plugin \
+    # create site for user data home, as returned by homebase (xdg spec)
+    && mkdir -p /home/user/.local/share \
+    && chown user:user -R /home/user/.local \
+    && rm -rf /tmp/*
+
+# install Ocean contrib packages (under EULA)
+RUN dwave install --all --yes \
+    && rm -rf /tmp/*
+
+# make sure ~/.cache is user-writeable, as the cloud-client uses it for disk cache
+RUN mkdir -p /home/user/.cache \
+    && chown user:user -R /home/user/.cache
+
+# install useful auxiliary Ocean packages (for tests, docs, examples)
+RUN pip install --no-cache-dir \
+        matplotlib jsonschema ipython tqdm \
+        pandas scipy scikit-learn imbalanced-learn tabulate \
+        mock coverage \
+        sphinx sphinx-rtd-theme \
+        seaborn ipympl \
+        jupyter \
+    && rm -rf /tmp/*
+
+CMD ["bash"]

--- a/dockerfiles/9/python3.13/trixie/tags.json
+++ b/dockerfiles/9/python3.13/trixie/tags.json
@@ -1,0 +1,13 @@
+{
+  "canonical_tag": "9.0.0-python3.13-trixie",
+  "alias_tags": [
+    "9-python3.13-trixie",
+    "9.0-python3.13-trixie",
+    "python3.13-trixie"
+  ],
+  "subtags": {
+    "ocean": "9.0.0",
+    "python": "3.13",
+    "platform": "trixie"
+  }
+}

--- a/dockerfiles/9/python3.9/trixie/Dockerfile
+++ b/dockerfiles/9/python3.9/trixie/Dockerfile
@@ -1,0 +1,107 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "python generate.py dockerfiles"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM python:3.9-trixie
+
+# setup locale
+RUN apt-get update \
+    && apt-get install -yq --no-install-recommends \
+        locales \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* \
+    && sed -i 's/^# *\(en_CA.UTF-8\)/\1/' /etc/locale.gen \
+    && locale-gen
+
+ENV LANG=en_CA.UTF-8
+
+# install basic packages
+RUN apt-get update \
+    && apt-get install -yq --no-install-recommends \
+        apt-utils \
+        bash-completion \
+        build-essential \
+        man-db \
+        zip \
+        unzip \
+        procps \
+        time \
+        lsof \
+        sudo \
+        htop \
+        less \
+        vim \
+        curl \
+        git \
+        jq \
+        # debugging: strace; ss, ip; netstat, arp, route
+        strace \
+        iproute2 \
+        net-tools \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/*
+
+# add a regular user
+RUN useradd -l -u 1000 -G sudo -md /home/user -s /bin/bash -p user user \
+    # passwordless sudo for users in the 'sudo' group
+    && sed -i.bkp -e 's/%sudo\s\+ALL=(ALL\(:ALL\)\?)\s\+ALL/%sudo ALL=NOPASSWD:ALL/g' /etc/sudoers
+ENV HOME=/home/user
+WORKDIR $HOME
+
+ENV \
+    # expose canonical image version
+    OCEAN_DEV_IMAGE_VERSION="9.0.0-python3.9-trixie" \
+    \
+    # we need PATH for user python packages during build as well
+    PATH="$HOME/.local/bin:$PATH" \
+    \
+    # supress pip version warnings (presumably pip will always be close to latest in our image)
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+# specify default python interpreter in the embedded devcontainer metadata
+LABEL devcontainer.metadata="[{\"customizations\": {\"vscode\": {\"extensions\": [\"ms-python.python\"], \"settings\": {\"python.defaultInterpreterPath\": \"/usr/local/bin/python\"}}}}]"
+
+# use sudo so that user does not get sudo usage info on (the first) login
+USER user
+RUN sudo echo "Running 'sudo' for user: success"
+
+# custom Bash prompt
+RUN { echo && echo "PS1='\[\e]0;ocean-dev\w\a\]\[\033[01;32m\]ocean-dev\[\033[00m\] \[\033[01;34m\]\w\[\033[00m\] \\\$ '" ; } >> .bashrc
+
+# few aliases
+RUN { echo && echo "alias ll='ls -l'" && echo "alias la='ls -la'"; } >> .bashrc
+
+# add help tip on start
+COPY data/auth-tip.sh /home/user/
+RUN { echo && echo "~/auth-tip.sh"; } >> .bashrc
+
+# install Ocean independently of other packages because pip is unable to
+# merge requirements gracefully (e.g. `requests` and `requests[socks]`)
+RUN pip install --no-cache-dir --upgrade pip setuptools wheel \
+    && pip install --no-cache-dir \
+        dwave-ocean-sdk==9.0.0 \
+        dwave-scikit-learn-plugin \
+    # create site for user data home, as returned by homebase (xdg spec)
+    && mkdir -p /home/user/.local/share \
+    && chown user:user -R /home/user/.local \
+    && rm -rf /tmp/*
+
+# install Ocean contrib packages (under EULA)
+RUN dwave install --all --yes \
+    && rm -rf /tmp/*
+
+# make sure ~/.cache is user-writeable, as the cloud-client uses it for disk cache
+RUN mkdir -p /home/user/.cache \
+    && chown user:user -R /home/user/.cache
+
+# install useful auxiliary Ocean packages (for tests, docs, examples)
+RUN pip install --no-cache-dir \
+        matplotlib jsonschema ipython tqdm \
+        pandas scipy scikit-learn imbalanced-learn tabulate \
+        mock coverage \
+        sphinx sphinx-rtd-theme \
+        seaborn ipympl \
+        jupyter \
+    && rm -rf /tmp/*
+
+CMD ["bash"]

--- a/dockerfiles/9/python3.9/trixie/tags.json
+++ b/dockerfiles/9/python3.9/trixie/tags.json
@@ -1,0 +1,13 @@
+{
+  "canonical_tag": "9.0.0-python3.9-trixie",
+  "alias_tags": [
+    "9-python3.9-trixie",
+    "9.0-python3.9-trixie",
+    "python3.9-trixie"
+  ],
+  "subtags": {
+    "ocean": "9.0.0",
+    "python": "3.9",
+    "platform": "trixie"
+  }
+}


### PR DESCRIPTION
[Trixie](https://www.debian.org/releases/trixie/) is the current "stable" release [as of 2025-08-09](https://www.debian.org/releases/).

In this PR we only add `trixie` to the matrix of images, keeping `bookworm` ("oldstable") the default until we verify everything works.

We should drop `bookworm` with the next Ocean minor release.