### PR TITLE
Build Ocean 9.4.0 images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 setup: true
 
 orbs:
-  path-filtering: circleci/path-filtering@1.0
+  path-filtering: circleci/path-filtering@3.0
 
 workflows:
   always-run:

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -56,7 +56,10 @@ ENV \
     PATH="$HOME/.local/bin:$PATH" \
     \
     # supress pip version warnings (presumably pip will always be close to latest in our image)
-    PIP_DISABLE_PIP_VERSION_CHECK=1
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    \
+    # suppress nodejs deprecation warnings, until this bug in vscode is fixed: https://github.com/microsoft/vscode/issues/301941
+    NODE_OPTIONS="--no-deprecation"
 
 # include Ocean dev container, https://github.com/dwavesystems/ocean-devcontainer at {{{ocean_devcontainer_version}}}
 LABEL devcontainer.metadata='[{{{ocean_devcontainer_json}}}]'

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ in metadata, currently version 1.3.0 (8c501fb).
 
 ## Build Matrix
 
-- Ocean: [`9.3.0`](https://github.com/dwavesystems/dwave-ocean-sdk/releases/9.3.0)
+- Ocean: [`9.4.0`](https://github.com/dwavesystems/dwave-ocean-sdk/releases/9.4.0)
 - Python: `3.10`, `3.11`, `3.12`, **`3.13`** (default), `3.14`
 - Platform: [`trixie`](https://wiki.debian.org/DebianTrixie) (default), `windowsservercore`
 
@@ -39,92 +39,92 @@ Shared tags map to multi-platform/multi-architecture images.
 
 ### Simple Tags
 
-- [Ocean: `9.3.0`, Python: `3.13`, Platform: `trixie`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/9/python3.13/trixie/Dockerfile)
+- [Ocean: `9.4.0`, Python: `3.13`, Platform: `trixie`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/9/python3.13/trixie/Dockerfile)
   - `9-python3.13-trixie`
   - `9-trixie`
-  - `9.3-python3.13-trixie`
-  - `9.3-trixie`
-  - `9.3.0-python3.13-trixie`
-  - `9.3.0-trixie`
+  - `9.4-python3.13-trixie`
+  - `9.4-trixie`
+  - `9.4.0-python3.13-trixie`
+  - `9.4.0-trixie`
   - `python3.13-trixie`
   - `trixie`
 
-- [Ocean: `9.3.0`, Python: `3.13`, Platform: `windowsservercore`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/9/python3.13/windowsservercore/Dockerfile)
+- [Ocean: `9.4.0`, Python: `3.13`, Platform: `windowsservercore`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/9/python3.13/windowsservercore/Dockerfile)
   - `9-python3.13-windowsservercore`
   - `9-windowsservercore`
-  - `9.3-python3.13-windowsservercore`
-  - `9.3-windowsservercore`
-  - `9.3.0-python3.13-windowsservercore`
-  - `9.3.0-windowsservercore`
+  - `9.4-python3.13-windowsservercore`
+  - `9.4-windowsservercore`
+  - `9.4.0-python3.13-windowsservercore`
+  - `9.4.0-windowsservercore`
   - `python3.13-windowsservercore`
   - `windowsservercore`
 
-- [Ocean: `9.3.0`, Python: `3.10`, Platform: `trixie`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/9/python3.10/trixie/Dockerfile)
+- [Ocean: `9.4.0`, Python: `3.10`, Platform: `trixie`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/9/python3.10/trixie/Dockerfile)
   - `9-python3.10-trixie`
-  - `9.3-python3.10-trixie`
-  - `9.3.0-python3.10-trixie`
+  - `9.4-python3.10-trixie`
+  - `9.4.0-python3.10-trixie`
   - `python3.10-trixie`
 
-- [Ocean: `9.3.0`, Python: `3.10`, Platform: `windowsservercore`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/9/python3.10/windowsservercore/Dockerfile)
+- [Ocean: `9.4.0`, Python: `3.10`, Platform: `windowsservercore`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/9/python3.10/windowsservercore/Dockerfile)
   - `9-python3.10-windowsservercore`
-  - `9.3-python3.10-windowsservercore`
-  - `9.3.0-python3.10-windowsservercore`
+  - `9.4-python3.10-windowsservercore`
+  - `9.4.0-python3.10-windowsservercore`
   - `python3.10-windowsservercore`
 
-- [Ocean: `9.3.0`, Python: `3.11`, Platform: `trixie`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/9/python3.11/trixie/Dockerfile)
+- [Ocean: `9.4.0`, Python: `3.11`, Platform: `trixie`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/9/python3.11/trixie/Dockerfile)
   - `9-python3.11-trixie`
-  - `9.3-python3.11-trixie`
-  - `9.3.0-python3.11-trixie`
+  - `9.4-python3.11-trixie`
+  - `9.4.0-python3.11-trixie`
   - `python3.11-trixie`
 
-- [Ocean: `9.3.0`, Python: `3.11`, Platform: `windowsservercore`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/9/python3.11/windowsservercore/Dockerfile)
+- [Ocean: `9.4.0`, Python: `3.11`, Platform: `windowsservercore`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/9/python3.11/windowsservercore/Dockerfile)
   - `9-python3.11-windowsservercore`
-  - `9.3-python3.11-windowsservercore`
-  - `9.3.0-python3.11-windowsservercore`
+  - `9.4-python3.11-windowsservercore`
+  - `9.4.0-python3.11-windowsservercore`
   - `python3.11-windowsservercore`
 
-- [Ocean: `9.3.0`, Python: `3.12`, Platform: `trixie`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/9/python3.12/trixie/Dockerfile)
+- [Ocean: `9.4.0`, Python: `3.12`, Platform: `trixie`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/9/python3.12/trixie/Dockerfile)
   - `9-python3.12-trixie`
-  - `9.3-python3.12-trixie`
-  - `9.3.0-python3.12-trixie`
+  - `9.4-python3.12-trixie`
+  - `9.4.0-python3.12-trixie`
   - `python3.12-trixie`
 
-- [Ocean: `9.3.0`, Python: `3.12`, Platform: `windowsservercore`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/9/python3.12/windowsservercore/Dockerfile)
+- [Ocean: `9.4.0`, Python: `3.12`, Platform: `windowsservercore`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/9/python3.12/windowsservercore/Dockerfile)
   - `9-python3.12-windowsservercore`
-  - `9.3-python3.12-windowsservercore`
-  - `9.3.0-python3.12-windowsservercore`
+  - `9.4-python3.12-windowsservercore`
+  - `9.4.0-python3.12-windowsservercore`
   - `python3.12-windowsservercore`
 
-- [Ocean: `9.3.0`, Python: `3.14`, Platform: `trixie`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/9/python3.14/trixie/Dockerfile)
+- [Ocean: `9.4.0`, Python: `3.14`, Platform: `trixie`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/9/python3.14/trixie/Dockerfile)
   - `9-python3.14-trixie`
-  - `9.3-python3.14-trixie`
-  - `9.3.0-python3.14-trixie`
+  - `9.4-python3.14-trixie`
+  - `9.4.0-python3.14-trixie`
   - `python3.14-trixie`
 
-- [Ocean: `9.3.0`, Python: `3.14`, Platform: `windowsservercore`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/9/python3.14/windowsservercore/Dockerfile)
+- [Ocean: `9.4.0`, Python: `3.14`, Platform: `windowsservercore`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/9/python3.14/windowsservercore/Dockerfile)
   - `9-python3.14-windowsservercore`
-  - `9.3-python3.14-windowsservercore`
-  - `9.3.0-python3.14-windowsservercore`
+  - `9.4-python3.14-windowsservercore`
+  - `9.4.0-python3.14-windowsservercore`
   - `python3.14-windowsservercore`
 
 
 ### Shared Tags
 
-- `9-python3.10`, `9.3-python3.10`, `9.3.0-python3.10`, `python3.10`
-  - [`9.3.0-python3.10-trixie`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/9/python3.10/trixie/Dockerfile)
-  - [`9.3.0-python3.10-windowsservercore`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/9/python3.10/windowsservercore/Dockerfile)
-- `9-python3.11`, `9.3-python3.11`, `9.3.0-python3.11`, `python3.11`
-  - [`9.3.0-python3.11-trixie`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/9/python3.11/trixie/Dockerfile)
-  - [`9.3.0-python3.11-windowsservercore`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/9/python3.11/windowsservercore/Dockerfile)
-- `9-python3.12`, `9.3-python3.12`, `9.3.0-python3.12`, `python3.12`
-  - [`9.3.0-python3.12-trixie`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/9/python3.12/trixie/Dockerfile)
-  - [`9.3.0-python3.12-windowsservercore`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/9/python3.12/windowsservercore/Dockerfile)
-- `9`, `9-python3.13`, `9.3`, `9.3-python3.13`, `9.3.0`, `9.3.0-python3.13`, `latest`, `python3.13`
-  - [`9.3.0-python3.13-trixie`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/9/python3.13/trixie/Dockerfile)
-  - [`9.3.0-python3.13-windowsservercore`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/9/python3.13/windowsservercore/Dockerfile)
-- `9-python3.14`, `9.3-python3.14`, `9.3.0-python3.14`, `python3.14`
-  - [`9.3.0-python3.14-trixie`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/9/python3.14/trixie/Dockerfile)
-  - [`9.3.0-python3.14-windowsservercore`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/9/python3.14/windowsservercore/Dockerfile)
+- `9-python3.10`, `9.4-python3.10`, `9.4.0-python3.10`, `python3.10`
+  - [`9.4.0-python3.10-trixie`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/9/python3.10/trixie/Dockerfile)
+  - [`9.4.0-python3.10-windowsservercore`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/9/python3.10/windowsservercore/Dockerfile)
+- `9-python3.11`, `9.4-python3.11`, `9.4.0-python3.11`, `python3.11`
+  - [`9.4.0-python3.11-trixie`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/9/python3.11/trixie/Dockerfile)
+  - [`9.4.0-python3.11-windowsservercore`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/9/python3.11/windowsservercore/Dockerfile)
+- `9-python3.12`, `9.4-python3.12`, `9.4.0-python3.12`, `python3.12`
+  - [`9.4.0-python3.12-trixie`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/9/python3.12/trixie/Dockerfile)
+  - [`9.4.0-python3.12-windowsservercore`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/9/python3.12/windowsservercore/Dockerfile)
+- `9`, `9-python3.13`, `9.4`, `9.4-python3.13`, `9.4.0`, `9.4.0-python3.13`, `latest`, `python3.13`
+  - [`9.4.0-python3.13-trixie`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/9/python3.13/trixie/Dockerfile)
+  - [`9.4.0-python3.13-windowsservercore`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/9/python3.13/windowsservercore/Dockerfile)
+- `9-python3.14`, `9.4-python3.14`, `9.4.0-python3.14`, `python3.14`
+  - [`9.4.0-python3.14-trixie`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/9/python3.14/trixie/Dockerfile)
+  - [`9.4.0-python3.14-windowsservercore`](https://github.com/dwavesystems/ocean-dev-docker/blob/master/dockerfiles/9/python3.14/windowsservercore/Dockerfile)
 
 
 ## License

--- a/dockerfiles/9/python3.10/trixie/Dockerfile
+++ b/dockerfiles/9/python3.10/trixie/Dockerfile
@@ -50,13 +50,16 @@ WORKDIR $HOME
 
 ENV \
     # expose canonical image version
-    OCEAN_DEV_IMAGE_VERSION="9.3.0-python3.10-trixie" \
+    OCEAN_DEV_IMAGE_VERSION="9.4.0-python3.10-trixie" \
     \
     # we need PATH for user python packages during build as well
     PATH="$HOME/.local/bin:$PATH" \
     \
     # supress pip version warnings (presumably pip will always be close to latest in our image)
-    PIP_DISABLE_PIP_VERSION_CHECK=1
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    \
+    # suppress nodejs deprecation warnings, until this bug in vscode is fixed: https://github.com/microsoft/vscode/issues/301941
+    NODE_OPTIONS="--no-deprecation"
 
 # include Ocean dev container, https://github.com/dwavesystems/ocean-devcontainer at 1.3.0 (8c501fb)
 LABEL devcontainer.metadata='[{"name": "Ocean Development Environment", "updateContentCommand": "[ ! -r requirements.txt ] || pip install -r requirements.txt", "forwardPorts": [18000, 18001, 18002, 18003, 18004, 36000, 36001, 36002, 36003, 36004], "portsAttributes": {"18000-18004": {"label": "D-Wave Problem Inspector", "requireLocalPort": true}, "36000-36004": {"label": "OAuth 2.0 authorization code redirect URI", "requireLocalPort": true}}, "customizations": {"vscode": {"settings": {"python.defaultInterpreterPath": "/usr/local/bin/python", "python.createEnvironment.trigger": "off", "workbench": {"editorAssociations": {"*.md": "vscode.markdown.preview.editor"}, "startupEditor": "readme"}}, "extensions": ["ms-python.python", "ms-toolsai.jupyter"]}}}]'
@@ -79,7 +82,7 @@ RUN { echo && echo "~/auth-tip.sh"; } >> .bashrc
 # merge requirements gracefully (e.g. `requests` and `requests[socks]`)
 RUN pip install --no-cache-dir --upgrade pip setuptools wheel \
     && pip install --no-cache-dir \
-        dwave-ocean-sdk==9.3.0 \
+        dwave-ocean-sdk==9.4.0 \
         dwave-scikit-learn-plugin \
     # create site for user data home, as returned by homebase (xdg spec)
     && mkdir -p /home/user/.local/share \

--- a/dockerfiles/9/python3.10/trixie/tags.json
+++ b/dockerfiles/9/python3.10/trixie/tags.json
@@ -1,12 +1,12 @@
 {
-  "canonical_tag": "9.3.0-python3.10-trixie",
+  "canonical_tag": "9.4.0-python3.10-trixie",
   "alias_tags": [
     "9-python3.10-trixie",
-    "9.3-python3.10-trixie",
+    "9.4-python3.10-trixie",
     "python3.10-trixie"
   ],
   "subtags": {
-    "ocean": "9.3.0",
+    "ocean": "9.4.0",
     "python": "3.10",
     "platform": "trixie"
   }

--- a/dockerfiles/9/python3.10/windowsservercore/Dockerfile
+++ b/dockerfiles/9/python3.10/windowsservercore/Dockerfile
@@ -8,7 +8,7 @@ FROM python:3.10-windowsservercore
 
 ENV \
     # expose canonical image version
-    OCEAN_DEV_IMAGE_VERSION="9.3.0-python3.10-windowsservercore" \
+    OCEAN_DEV_IMAGE_VERSION="9.4.0-python3.10-windowsservercore" \
     \
     # supress pip version warnings (presumably pip will always be close to latest in our image)
     PIP_DISABLE_PIP_VERSION_CHECK=1
@@ -33,7 +33,7 @@ RUN \
 # install Ocean independently of other packages because pip is unable to
 # merge requirements gracefully (e.g. `requests` and `requests[socks]`)
 RUN pip install --no-cache-dir \
-        dwave-ocean-sdk==9.3.0 \
+        dwave-ocean-sdk==9.4.0 \
         dwave-scikit-learn-plugin
     # TODO: create site for user data home, as returned by homebase (xdg spec)
     # TODO: delete temporary files, if any

--- a/dockerfiles/9/python3.10/windowsservercore/tags.json
+++ b/dockerfiles/9/python3.10/windowsservercore/tags.json
@@ -1,12 +1,12 @@
 {
-  "canonical_tag": "9.3.0-python3.10-windowsservercore",
+  "canonical_tag": "9.4.0-python3.10-windowsservercore",
   "alias_tags": [
     "9-python3.10-windowsservercore",
-    "9.3-python3.10-windowsservercore",
+    "9.4-python3.10-windowsservercore",
     "python3.10-windowsservercore"
   ],
   "subtags": {
-    "ocean": "9.3.0",
+    "ocean": "9.4.0",
     "python": "3.10",
     "platform": "windowsservercore"
   }

--- a/dockerfiles/9/python3.11/trixie/Dockerfile
+++ b/dockerfiles/9/python3.11/trixie/Dockerfile
@@ -50,13 +50,16 @@ WORKDIR $HOME
 
 ENV \
     # expose canonical image version
-    OCEAN_DEV_IMAGE_VERSION="9.3.0-python3.11-trixie" \
+    OCEAN_DEV_IMAGE_VERSION="9.4.0-python3.11-trixie" \
     \
     # we need PATH for user python packages during build as well
     PATH="$HOME/.local/bin:$PATH" \
     \
     # supress pip version warnings (presumably pip will always be close to latest in our image)
-    PIP_DISABLE_PIP_VERSION_CHECK=1
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    \
+    # suppress nodejs deprecation warnings, until this bug in vscode is fixed: https://github.com/microsoft/vscode/issues/301941
+    NODE_OPTIONS="--no-deprecation"
 
 # include Ocean dev container, https://github.com/dwavesystems/ocean-devcontainer at 1.3.0 (8c501fb)
 LABEL devcontainer.metadata='[{"name": "Ocean Development Environment", "updateContentCommand": "[ ! -r requirements.txt ] || pip install -r requirements.txt", "forwardPorts": [18000, 18001, 18002, 18003, 18004, 36000, 36001, 36002, 36003, 36004], "portsAttributes": {"18000-18004": {"label": "D-Wave Problem Inspector", "requireLocalPort": true}, "36000-36004": {"label": "OAuth 2.0 authorization code redirect URI", "requireLocalPort": true}}, "customizations": {"vscode": {"settings": {"python.defaultInterpreterPath": "/usr/local/bin/python", "python.createEnvironment.trigger": "off", "workbench": {"editorAssociations": {"*.md": "vscode.markdown.preview.editor"}, "startupEditor": "readme"}}, "extensions": ["ms-python.python", "ms-toolsai.jupyter"]}}}]'
@@ -79,7 +82,7 @@ RUN { echo && echo "~/auth-tip.sh"; } >> .bashrc
 # merge requirements gracefully (e.g. `requests` and `requests[socks]`)
 RUN pip install --no-cache-dir --upgrade pip setuptools wheel \
     && pip install --no-cache-dir \
-        dwave-ocean-sdk==9.3.0 \
+        dwave-ocean-sdk==9.4.0 \
         dwave-scikit-learn-plugin \
     # create site for user data home, as returned by homebase (xdg spec)
     && mkdir -p /home/user/.local/share \

--- a/dockerfiles/9/python3.11/trixie/tags.json
+++ b/dockerfiles/9/python3.11/trixie/tags.json
@@ -1,12 +1,12 @@
 {
-  "canonical_tag": "9.3.0-python3.11-trixie",
+  "canonical_tag": "9.4.0-python3.11-trixie",
   "alias_tags": [
     "9-python3.11-trixie",
-    "9.3-python3.11-trixie",
+    "9.4-python3.11-trixie",
     "python3.11-trixie"
   ],
   "subtags": {
-    "ocean": "9.3.0",
+    "ocean": "9.4.0",
     "python": "3.11",
     "platform": "trixie"
   }

--- a/dockerfiles/9/python3.11/windowsservercore/Dockerfile
+++ b/dockerfiles/9/python3.11/windowsservercore/Dockerfile
@@ -8,7 +8,7 @@ FROM python:3.11-windowsservercore
 
 ENV \
     # expose canonical image version
-    OCEAN_DEV_IMAGE_VERSION="9.3.0-python3.11-windowsservercore" \
+    OCEAN_DEV_IMAGE_VERSION="9.4.0-python3.11-windowsservercore" \
     \
     # supress pip version warnings (presumably pip will always be close to latest in our image)
     PIP_DISABLE_PIP_VERSION_CHECK=1
@@ -33,7 +33,7 @@ RUN \
 # install Ocean independently of other packages because pip is unable to
 # merge requirements gracefully (e.g. `requests` and `requests[socks]`)
 RUN pip install --no-cache-dir \
-        dwave-ocean-sdk==9.3.0 \
+        dwave-ocean-sdk==9.4.0 \
         dwave-scikit-learn-plugin
     # TODO: create site for user data home, as returned by homebase (xdg spec)
     # TODO: delete temporary files, if any

--- a/dockerfiles/9/python3.11/windowsservercore/tags.json
+++ b/dockerfiles/9/python3.11/windowsservercore/tags.json
@@ -1,12 +1,12 @@
 {
-  "canonical_tag": "9.3.0-python3.11-windowsservercore",
+  "canonical_tag": "9.4.0-python3.11-windowsservercore",
   "alias_tags": [
     "9-python3.11-windowsservercore",
-    "9.3-python3.11-windowsservercore",
+    "9.4-python3.11-windowsservercore",
     "python3.11-windowsservercore"
   ],
   "subtags": {
-    "ocean": "9.3.0",
+    "ocean": "9.4.0",
     "python": "3.11",
     "platform": "windowsservercore"
   }

--- a/dockerfiles/9/python3.12/trixie/Dockerfile
+++ b/dockerfiles/9/python3.12/trixie/Dockerfile
@@ -50,13 +50,16 @@ WORKDIR $HOME
 
 ENV \
     # expose canonical image version
-    OCEAN_DEV_IMAGE_VERSION="9.3.0-python3.12-trixie" \
+    OCEAN_DEV_IMAGE_VERSION="9.4.0-python3.12-trixie" \
     \
     # we need PATH for user python packages during build as well
     PATH="$HOME/.local/bin:$PATH" \
     \
     # supress pip version warnings (presumably pip will always be close to latest in our image)
-    PIP_DISABLE_PIP_VERSION_CHECK=1
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    \
+    # suppress nodejs deprecation warnings, until this bug in vscode is fixed: https://github.com/microsoft/vscode/issues/301941
+    NODE_OPTIONS="--no-deprecation"
 
 # include Ocean dev container, https://github.com/dwavesystems/ocean-devcontainer at 1.3.0 (8c501fb)
 LABEL devcontainer.metadata='[{"name": "Ocean Development Environment", "updateContentCommand": "[ ! -r requirements.txt ] || pip install -r requirements.txt", "forwardPorts": [18000, 18001, 18002, 18003, 18004, 36000, 36001, 36002, 36003, 36004], "portsAttributes": {"18000-18004": {"label": "D-Wave Problem Inspector", "requireLocalPort": true}, "36000-36004": {"label": "OAuth 2.0 authorization code redirect URI", "requireLocalPort": true}}, "customizations": {"vscode": {"settings": {"python.defaultInterpreterPath": "/usr/local/bin/python", "python.createEnvironment.trigger": "off", "workbench": {"editorAssociations": {"*.md": "vscode.markdown.preview.editor"}, "startupEditor": "readme"}}, "extensions": ["ms-python.python", "ms-toolsai.jupyter"]}}}]'
@@ -79,7 +82,7 @@ RUN { echo && echo "~/auth-tip.sh"; } >> .bashrc
 # merge requirements gracefully (e.g. `requests` and `requests[socks]`)
 RUN pip install --no-cache-dir --upgrade pip setuptools wheel \
     && pip install --no-cache-dir \
-        dwave-ocean-sdk==9.3.0 \
+        dwave-ocean-sdk==9.4.0 \
         dwave-scikit-learn-plugin \
     # create site for user data home, as returned by homebase (xdg spec)
     && mkdir -p /home/user/.local/share \

--- a/dockerfiles/9/python3.12/trixie/tags.json
+++ b/dockerfiles/9/python3.12/trixie/tags.json
@@ -1,12 +1,12 @@
 {
-  "canonical_tag": "9.3.0-python3.12-trixie",
+  "canonical_tag": "9.4.0-python3.12-trixie",
   "alias_tags": [
     "9-python3.12-trixie",
-    "9.3-python3.12-trixie",
+    "9.4-python3.12-trixie",
     "python3.12-trixie"
   ],
   "subtags": {
-    "ocean": "9.3.0",
+    "ocean": "9.4.0",
     "python": "3.12",
     "platform": "trixie"
   }

--- a/dockerfiles/9/python3.12/windowsservercore/Dockerfile
+++ b/dockerfiles/9/python3.12/windowsservercore/Dockerfile
@@ -8,7 +8,7 @@ FROM python:3.12-windowsservercore
 
 ENV \
     # expose canonical image version
-    OCEAN_DEV_IMAGE_VERSION="9.3.0-python3.12-windowsservercore" \
+    OCEAN_DEV_IMAGE_VERSION="9.4.0-python3.12-windowsservercore" \
     \
     # supress pip version warnings (presumably pip will always be close to latest in our image)
     PIP_DISABLE_PIP_VERSION_CHECK=1
@@ -33,7 +33,7 @@ RUN \
 # install Ocean independently of other packages because pip is unable to
 # merge requirements gracefully (e.g. `requests` and `requests[socks]`)
 RUN pip install --no-cache-dir \
-        dwave-ocean-sdk==9.3.0 \
+        dwave-ocean-sdk==9.4.0 \
         dwave-scikit-learn-plugin
     # TODO: create site for user data home, as returned by homebase (xdg spec)
     # TODO: delete temporary files, if any

--- a/dockerfiles/9/python3.12/windowsservercore/tags.json
+++ b/dockerfiles/9/python3.12/windowsservercore/tags.json
@@ -1,12 +1,12 @@
 {
-  "canonical_tag": "9.3.0-python3.12-windowsservercore",
+  "canonical_tag": "9.4.0-python3.12-windowsservercore",
   "alias_tags": [
     "9-python3.12-windowsservercore",
-    "9.3-python3.12-windowsservercore",
+    "9.4-python3.12-windowsservercore",
     "python3.12-windowsservercore"
   ],
   "subtags": {
-    "ocean": "9.3.0",
+    "ocean": "9.4.0",
     "python": "3.12",
     "platform": "windowsservercore"
   }

--- a/dockerfiles/9/python3.13/trixie/Dockerfile
+++ b/dockerfiles/9/python3.13/trixie/Dockerfile
@@ -50,13 +50,16 @@ WORKDIR $HOME
 
 ENV \
     # expose canonical image version
-    OCEAN_DEV_IMAGE_VERSION="9.3.0-python3.13-trixie" \
+    OCEAN_DEV_IMAGE_VERSION="9.4.0-python3.13-trixie" \
     \
     # we need PATH for user python packages during build as well
     PATH="$HOME/.local/bin:$PATH" \
     \
     # supress pip version warnings (presumably pip will always be close to latest in our image)
-    PIP_DISABLE_PIP_VERSION_CHECK=1
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    \
+    # suppress nodejs deprecation warnings, until this bug in vscode is fixed: https://github.com/microsoft/vscode/issues/301941
+    NODE_OPTIONS="--no-deprecation"
 
 # include Ocean dev container, https://github.com/dwavesystems/ocean-devcontainer at 1.3.0 (8c501fb)
 LABEL devcontainer.metadata='[{"name": "Ocean Development Environment", "updateContentCommand": "[ ! -r requirements.txt ] || pip install -r requirements.txt", "forwardPorts": [18000, 18001, 18002, 18003, 18004, 36000, 36001, 36002, 36003, 36004], "portsAttributes": {"18000-18004": {"label": "D-Wave Problem Inspector", "requireLocalPort": true}, "36000-36004": {"label": "OAuth 2.0 authorization code redirect URI", "requireLocalPort": true}}, "customizations": {"vscode": {"settings": {"python.defaultInterpreterPath": "/usr/local/bin/python", "python.createEnvironment.trigger": "off", "workbench": {"editorAssociations": {"*.md": "vscode.markdown.preview.editor"}, "startupEditor": "readme"}}, "extensions": ["ms-python.python", "ms-toolsai.jupyter"]}}}]'
@@ -79,7 +82,7 @@ RUN { echo && echo "~/auth-tip.sh"; } >> .bashrc
 # merge requirements gracefully (e.g. `requests` and `requests[socks]`)
 RUN pip install --no-cache-dir --upgrade pip setuptools wheel \
     && pip install --no-cache-dir \
-        dwave-ocean-sdk==9.3.0 \
+        dwave-ocean-sdk==9.4.0 \
         dwave-scikit-learn-plugin \
     # create site for user data home, as returned by homebase (xdg spec)
     && mkdir -p /home/user/.local/share \

--- a/dockerfiles/9/python3.13/trixie/tags.json
+++ b/dockerfiles/9/python3.13/trixie/tags.json
@@ -1,16 +1,16 @@
 {
-  "canonical_tag": "9.3.0-python3.13-trixie",
+  "canonical_tag": "9.4.0-python3.13-trixie",
   "alias_tags": [
     "9-python3.13-trixie",
     "9-trixie",
-    "9.3-python3.13-trixie",
-    "9.3-trixie",
-    "9.3.0-trixie",
+    "9.4-python3.13-trixie",
+    "9.4-trixie",
+    "9.4.0-trixie",
     "python3.13-trixie",
     "trixie"
   ],
   "subtags": {
-    "ocean": "9.3.0",
+    "ocean": "9.4.0",
     "python": "3.13",
     "platform": "trixie"
   }

--- a/dockerfiles/9/python3.13/windowsservercore/Dockerfile
+++ b/dockerfiles/9/python3.13/windowsservercore/Dockerfile
@@ -8,7 +8,7 @@ FROM python:3.13-windowsservercore
 
 ENV \
     # expose canonical image version
-    OCEAN_DEV_IMAGE_VERSION="9.3.0-python3.13-windowsservercore" \
+    OCEAN_DEV_IMAGE_VERSION="9.4.0-python3.13-windowsservercore" \
     \
     # supress pip version warnings (presumably pip will always be close to latest in our image)
     PIP_DISABLE_PIP_VERSION_CHECK=1
@@ -33,7 +33,7 @@ RUN \
 # install Ocean independently of other packages because pip is unable to
 # merge requirements gracefully (e.g. `requests` and `requests[socks]`)
 RUN pip install --no-cache-dir \
-        dwave-ocean-sdk==9.3.0 \
+        dwave-ocean-sdk==9.4.0 \
         dwave-scikit-learn-plugin
     # TODO: create site for user data home, as returned by homebase (xdg spec)
     # TODO: delete temporary files, if any

--- a/dockerfiles/9/python3.13/windowsservercore/tags.json
+++ b/dockerfiles/9/python3.13/windowsservercore/tags.json
@@ -1,16 +1,16 @@
 {
-  "canonical_tag": "9.3.0-python3.13-windowsservercore",
+  "canonical_tag": "9.4.0-python3.13-windowsservercore",
   "alias_tags": [
     "9-python3.13-windowsservercore",
     "9-windowsservercore",
-    "9.3-python3.13-windowsservercore",
-    "9.3-windowsservercore",
-    "9.3.0-windowsservercore",
+    "9.4-python3.13-windowsservercore",
+    "9.4-windowsservercore",
+    "9.4.0-windowsservercore",
     "python3.13-windowsservercore",
     "windowsservercore"
   ],
   "subtags": {
-    "ocean": "9.3.0",
+    "ocean": "9.4.0",
     "python": "3.13",
     "platform": "windowsservercore"
   }

--- a/dockerfiles/9/python3.14/trixie/Dockerfile
+++ b/dockerfiles/9/python3.14/trixie/Dockerfile
@@ -50,13 +50,16 @@ WORKDIR $HOME
 
 ENV \
     # expose canonical image version
-    OCEAN_DEV_IMAGE_VERSION="9.3.0-python3.14-trixie" \
+    OCEAN_DEV_IMAGE_VERSION="9.4.0-python3.14-trixie" \
     \
     # we need PATH for user python packages during build as well
     PATH="$HOME/.local/bin:$PATH" \
     \
     # supress pip version warnings (presumably pip will always be close to latest in our image)
-    PIP_DISABLE_PIP_VERSION_CHECK=1
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    \
+    # suppress nodejs deprecation warnings, until this bug in vscode is fixed: https://github.com/microsoft/vscode/issues/301941
+    NODE_OPTIONS="--no-deprecation"
 
 # include Ocean dev container, https://github.com/dwavesystems/ocean-devcontainer at 1.3.0 (8c501fb)
 LABEL devcontainer.metadata='[{"name": "Ocean Development Environment", "updateContentCommand": "[ ! -r requirements.txt ] || pip install -r requirements.txt", "forwardPorts": [18000, 18001, 18002, 18003, 18004, 36000, 36001, 36002, 36003, 36004], "portsAttributes": {"18000-18004": {"label": "D-Wave Problem Inspector", "requireLocalPort": true}, "36000-36004": {"label": "OAuth 2.0 authorization code redirect URI", "requireLocalPort": true}}, "customizations": {"vscode": {"settings": {"python.defaultInterpreterPath": "/usr/local/bin/python", "python.createEnvironment.trigger": "off", "workbench": {"editorAssociations": {"*.md": "vscode.markdown.preview.editor"}, "startupEditor": "readme"}}, "extensions": ["ms-python.python", "ms-toolsai.jupyter"]}}}]'
@@ -79,7 +82,7 @@ RUN { echo && echo "~/auth-tip.sh"; } >> .bashrc
 # merge requirements gracefully (e.g. `requests` and `requests[socks]`)
 RUN pip install --no-cache-dir --upgrade pip setuptools wheel \
     && pip install --no-cache-dir \
-        dwave-ocean-sdk==9.3.0 \
+        dwave-ocean-sdk==9.4.0 \
         dwave-scikit-learn-plugin \
     # create site for user data home, as returned by homebase (xdg spec)
     && mkdir -p /home/user/.local/share \

--- a/dockerfiles/9/python3.14/trixie/tags.json
+++ b/dockerfiles/9/python3.14/trixie/tags.json
@@ -1,12 +1,12 @@
 {
-  "canonical_tag": "9.3.0-python3.14-trixie",
+  "canonical_tag": "9.4.0-python3.14-trixie",
   "alias_tags": [
     "9-python3.14-trixie",
-    "9.3-python3.14-trixie",
+    "9.4-python3.14-trixie",
     "python3.14-trixie"
   ],
   "subtags": {
-    "ocean": "9.3.0",
+    "ocean": "9.4.0",
     "python": "3.14",
     "platform": "trixie"
   }

--- a/dockerfiles/9/python3.14/windowsservercore/Dockerfile
+++ b/dockerfiles/9/python3.14/windowsservercore/Dockerfile
@@ -8,7 +8,7 @@ FROM python:3.14-windowsservercore
 
 ENV \
     # expose canonical image version
-    OCEAN_DEV_IMAGE_VERSION="9.3.0-python3.14-windowsservercore" \
+    OCEAN_DEV_IMAGE_VERSION="9.4.0-python3.14-windowsservercore" \
     \
     # supress pip version warnings (presumably pip will always be close to latest in our image)
     PIP_DISABLE_PIP_VERSION_CHECK=1
@@ -33,7 +33,7 @@ RUN \
 # install Ocean independently of other packages because pip is unable to
 # merge requirements gracefully (e.g. `requests` and `requests[socks]`)
 RUN pip install --no-cache-dir \
-        dwave-ocean-sdk==9.3.0 \
+        dwave-ocean-sdk==9.4.0 \
         dwave-scikit-learn-plugin
     # TODO: create site for user data home, as returned by homebase (xdg spec)
     # TODO: delete temporary files, if any

--- a/dockerfiles/9/python3.14/windowsservercore/tags.json
+++ b/dockerfiles/9/python3.14/windowsservercore/tags.json
@@ -1,12 +1,12 @@
 {
-  "canonical_tag": "9.3.0-python3.14-windowsservercore",
+  "canonical_tag": "9.4.0-python3.14-windowsservercore",
   "alias_tags": [
     "9-python3.14-windowsservercore",
-    "9.3-python3.14-windowsservercore",
+    "9.4-python3.14-windowsservercore",
     "python3.14-windowsservercore"
   ],
   "subtags": {
-    "ocean": "9.3.0",
+    "ocean": "9.4.0",
     "python": "3.14",
     "platform": "windowsservercore"
   }

--- a/dockerfiles/9/shared-tags.json
+++ b/dockerfiles/9/shared-tags.json
@@ -1,98 +1,98 @@
 {
   "latest": [
-    "9.3.0-python3.13-trixie",
-    "9.3.0-python3.13-windowsservercore"
+    "9.4.0-python3.13-trixie",
+    "9.4.0-python3.13-windowsservercore"
   ],
   "python3.10": [
-    "9.3.0-python3.10-trixie",
-    "9.3.0-python3.10-windowsservercore"
+    "9.4.0-python3.10-trixie",
+    "9.4.0-python3.10-windowsservercore"
   ],
   "python3.11": [
-    "9.3.0-python3.11-trixie",
-    "9.3.0-python3.11-windowsservercore"
+    "9.4.0-python3.11-trixie",
+    "9.4.0-python3.11-windowsservercore"
   ],
   "python3.12": [
-    "9.3.0-python3.12-trixie",
-    "9.3.0-python3.12-windowsservercore"
+    "9.4.0-python3.12-trixie",
+    "9.4.0-python3.12-windowsservercore"
   ],
   "python3.13": [
-    "9.3.0-python3.13-trixie",
-    "9.3.0-python3.13-windowsservercore"
+    "9.4.0-python3.13-trixie",
+    "9.4.0-python3.13-windowsservercore"
   ],
   "python3.14": [
-    "9.3.0-python3.14-trixie",
-    "9.3.0-python3.14-windowsservercore"
+    "9.4.0-python3.14-trixie",
+    "9.4.0-python3.14-windowsservercore"
   ],
   "9": [
-    "9.3.0-python3.13-trixie",
-    "9.3.0-python3.13-windowsservercore"
+    "9.4.0-python3.13-trixie",
+    "9.4.0-python3.13-windowsservercore"
   ],
   "9-python3.10": [
-    "9.3.0-python3.10-trixie",
-    "9.3.0-python3.10-windowsservercore"
+    "9.4.0-python3.10-trixie",
+    "9.4.0-python3.10-windowsservercore"
   ],
   "9-python3.11": [
-    "9.3.0-python3.11-trixie",
-    "9.3.0-python3.11-windowsservercore"
+    "9.4.0-python3.11-trixie",
+    "9.4.0-python3.11-windowsservercore"
   ],
   "9-python3.12": [
-    "9.3.0-python3.12-trixie",
-    "9.3.0-python3.12-windowsservercore"
+    "9.4.0-python3.12-trixie",
+    "9.4.0-python3.12-windowsservercore"
   ],
   "9-python3.13": [
-    "9.3.0-python3.13-trixie",
-    "9.3.0-python3.13-windowsservercore"
+    "9.4.0-python3.13-trixie",
+    "9.4.0-python3.13-windowsservercore"
   ],
   "9-python3.14": [
-    "9.3.0-python3.14-trixie",
-    "9.3.0-python3.14-windowsservercore"
+    "9.4.0-python3.14-trixie",
+    "9.4.0-python3.14-windowsservercore"
   ],
-  "9.3": [
-    "9.3.0-python3.13-trixie",
-    "9.3.0-python3.13-windowsservercore"
+  "9.4": [
+    "9.4.0-python3.13-trixie",
+    "9.4.0-python3.13-windowsservercore"
   ],
-  "9.3-python3.10": [
-    "9.3.0-python3.10-trixie",
-    "9.3.0-python3.10-windowsservercore"
+  "9.4-python3.10": [
+    "9.4.0-python3.10-trixie",
+    "9.4.0-python3.10-windowsservercore"
   ],
-  "9.3-python3.11": [
-    "9.3.0-python3.11-trixie",
-    "9.3.0-python3.11-windowsservercore"
+  "9.4-python3.11": [
+    "9.4.0-python3.11-trixie",
+    "9.4.0-python3.11-windowsservercore"
   ],
-  "9.3-python3.12": [
-    "9.3.0-python3.12-trixie",
-    "9.3.0-python3.12-windowsservercore"
+  "9.4-python3.12": [
+    "9.4.0-python3.12-trixie",
+    "9.4.0-python3.12-windowsservercore"
   ],
-  "9.3-python3.13": [
-    "9.3.0-python3.13-trixie",
-    "9.3.0-python3.13-windowsservercore"
+  "9.4-python3.13": [
+    "9.4.0-python3.13-trixie",
+    "9.4.0-python3.13-windowsservercore"
   ],
-  "9.3-python3.14": [
-    "9.3.0-python3.14-trixie",
-    "9.3.0-python3.14-windowsservercore"
+  "9.4-python3.14": [
+    "9.4.0-python3.14-trixie",
+    "9.4.0-python3.14-windowsservercore"
   ],
-  "9.3.0": [
-    "9.3.0-python3.13-trixie",
-    "9.3.0-python3.13-windowsservercore"
+  "9.4.0": [
+    "9.4.0-python3.13-trixie",
+    "9.4.0-python3.13-windowsservercore"
   ],
-  "9.3.0-python3.10": [
-    "9.3.0-python3.10-trixie",
-    "9.3.0-python3.10-windowsservercore"
+  "9.4.0-python3.10": [
+    "9.4.0-python3.10-trixie",
+    "9.4.0-python3.10-windowsservercore"
   ],
-  "9.3.0-python3.11": [
-    "9.3.0-python3.11-trixie",
-    "9.3.0-python3.11-windowsservercore"
+  "9.4.0-python3.11": [
+    "9.4.0-python3.11-trixie",
+    "9.4.0-python3.11-windowsservercore"
   ],
-  "9.3.0-python3.12": [
-    "9.3.0-python3.12-trixie",
-    "9.3.0-python3.12-windowsservercore"
+  "9.4.0-python3.12": [
+    "9.4.0-python3.12-trixie",
+    "9.4.0-python3.12-windowsservercore"
   ],
-  "9.3.0-python3.13": [
-    "9.3.0-python3.13-trixie",
-    "9.3.0-python3.13-windowsservercore"
+  "9.4.0-python3.13": [
+    "9.4.0-python3.13-trixie",
+    "9.4.0-python3.13-windowsservercore"
   ],
-  "9.3.0-python3.14": [
-    "9.3.0-python3.14-trixie",
-    "9.3.0-python3.14-windowsservercore"
+  "9.4.0-python3.14": [
+    "9.4.0-python3.14-trixie",
+    "9.4.0-python3.14-windowsservercore"
   ]
 }


### PR DESCRIPTION
- **Temporarily disable nodejs deprecation warnings to clean-up auth CLI**
- **Generate Ocean 9.4.0 dockerfiles, tags and readme**
